### PR TITLE
bsc#1071539 - remove left over pagecache limit references and fate#325363 - change the behavior of sapconf after installation

### DIFF
--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -239,45 +239,7 @@ SAP Note 2131662, 2205917, 2031375
 .PP
 .TP 0
 .BI "Linux paging improvements"
-Tune page cache limit to prevent eviction of SAP applications memory into swap
-.RS 4
-.TP 3
-.BI ENABLE_PAGECACHE_LIMIT="no"
-Consider to enable pagecache limit feature if your SAP workloads cause frequent and excessive swapping activities. It is recommended to leave pagecache limit disabled if the system has low or no swap space.
-.PP
-.RS 3
-This parameter is used in the common part (tune_page_cache_limit) of the scripting to control the setting of \fBvm.pagecache_limit_mb\fP
-.br
-SAP Note 1557506
-.RE
-.TP 3
-.BI #PAGECACHE_LIMIT_MB=""
-When the pagecache limit feature (see value above) is \fBenabled\fP, the limit value has to set manually by setting this parameter to the desired limit value.
-.br
-This parameter is commented out by default, so please \fIuncomment\fP the line containing \fBPAGECACHE_LIMIT_MB=""\fP and set your preferred value. 
-.PP
-.RS 3
-This will set \fBvm.pagecache_limit_mb\fP during the common part (tune_page_cache_limit) of the scripting. If the parameter \fBPAGECACHE_LIMIT_MB=""\fP is still commented out or empty although ENABLE_PAGECACHE_LIMIT is set to "yes", the pagecache limit feature will be disabled by setting \fBvm.pagecache_limit_mb\fP to 0. A hint is logged to \fI/var/log/sapconf.log\fP
-.br
-SAP Note 1557506
-.RE
-.TP 3
-.BI #PAGECACHE_LIMIT_IGNORE_DIRTY=""
-Whether or not to ignore dirty memory when enforcing the pagecache limit.
-.br
-.RS 3
-If set to 0, dirty memory will be freed (written onto disk) when enforcing the pagecache limit.
-.br
-If set to 1 (default), dirty memory will not be freed when enforcing the pagecache limit.
-.br
-If set to 2 a middle ground, some dirty memory will be freed when enforcing the limit.
-.br
-This parameter is commented out by default, so please \fIuncomment\fP the line containing \fBPAGECACHE_LIMIT_IGNORE_DIRTY=""\fP and set your preferred value. 
-.PP
-This will set \fBvm.pagecache_limit_ignore_dirty\fP during the common part (tune_page_cache_limit) of the scripting.
-.br
-SAP Note 1557506
-.RE
+no longer supported since SLE15.
 .PP
 .SH DESCRIPTION OF PART 2
 The parameters of the second part of the configuration file are not changeable in /etc/sysconfig/sapconf. They are part of this file for documentation purpose only.

--- a/man/tuned-profiles-sap-ase.7
+++ b/man/tuned-profiles-sap-ase.7
@@ -36,8 +36,6 @@ Maximum number of open file descriptors in /etc/security/limits.conf
 .IP \[bu]
 Set the maximum number of OS tasks each user may run concurrently (UserTasksMax)
 .IP \[bu]
-Pagecache limit: vm.pagecache_limit_mb, pagecache_limit_ignore_dirty
-.IP \[bu]
 Set number of requests for block devices:
 .br /sys/block/sd*/queue/nr_requests
 .IP \[bu]
@@ -63,7 +61,7 @@ tuned-adm profile sap-ase
 .PP
 \fI/etc/sysconfig/sapconf\fR
 .RS 4
-Define the behaviour and overrides for the common settings from 1275776 and tuning pagecache limit.
+Define the behaviour and overrides for the common settings from 1275776.
 .RE
 .PP
 \fI/etc/sysconfig/sapnote\-1680803\fR

--- a/man/tuned-profiles-sap-bobj.7
+++ b/man/tuned-profiles-sap-bobj.7
@@ -35,8 +35,6 @@ Maximum number of open file descriptors in /etc/security/limits.conf
 .IP \[bu]
 Set the maximum number of OS tasks each user may run concurrently (UserTasksMax)
 .IP \[bu]
-Pagecache limit: vm.pagecache_limit_mb, pagecache_limit_ignore_dirty
-.IP \[bu]
 CPU power management, disk cache, kernel scheduling and VM tweaks (inherited from throughput-performance profile).
 .IP \[bu]
 Enable uuidd.socket.
@@ -53,7 +51,7 @@ tuned-adm profile sap-bobj
 .PP
 \fI/etc/sysconfig/sapconf\fR
 .RS 4
-Define the behaviour and overrides for the common settings from 1275776 and tuning pagecache limit.
+Define the behaviour and overrides for the common settings from 1275776.
 .RE
 .PP
 \fI/usr/lib/tuned/sap-bobj/tuned.conf\fR

--- a/man/tuned-profiles-sap-hana.7
+++ b/man/tuned-profiles-sap-hana.7
@@ -35,8 +35,6 @@ Maximum number of open file descriptors in /etc/security/limits.conf
 .IP \[bu]
 Set the maximum number of OS tasks each user may run concurrently (UserTasksMax)
 .IP \[bu]
-Pagecache limit: vm.pagecache_limit_mb, pagecache_limit_ignore_dirty
-.IP \[bu]
 Dirty memory: Set vm.dirty_bytes and vm.dirty_background_bytes
 .IP \[bu]
 Disable TCP slow start on idle connections: net.ipv4.tcp_slow_start_after_idle

--- a/man/tuned-profiles-sap-netweaver.7
+++ b/man/tuned-profiles-sap-netweaver.7
@@ -35,8 +35,6 @@ Maximum number of open file descriptors in /etc/security/limits.conf
 .IP \[bu]
 Set the maximum number of OS tasks each user may run concurrently (UserTasksMax)
 .IP \[bu]
-Pagecache limit: vm.pagecache_limit_mb, pagecache_limit_ignore_dirty
-.IP \[bu]
 Dirty memory: Set vm.dirty_bytes and vm.dirty_background_bytes
 .IP \[bu]
 Disable TCP slow start on idle connections: net.ipv4.tcp_slow_start_after_idle

--- a/profile/sap-ase/script.sh
+++ b/profile/sap-ase/script.sh
@@ -11,8 +11,6 @@ start() {
     log "--- Going to apply ASE tuning techniques"
     # Apply tuning techniques from 1275776 - Preparing SLES for SAP and 1984787 - Installation notes
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
-    tune_page_cache_limit
     # SAP note 1984787 - Installation notes
     tune_uuidd_socket
 
@@ -117,7 +115,6 @@ start() {
 stop() {
     log "--- Going to revert ASE tuned parameters"
     revert_preparation
-    revert_page_cache_limit
     revert_uuidd_socket
     revert_shmmni
 

--- a/profile/sap-bobj/script.sh
+++ b/profile/sap-bobj/script.sh
@@ -9,8 +9,6 @@ start() {
     log "--- Going to apply BOBJ tuning techniques"
     # Apply tuning techniques from 1275776 - Preparing SLES for SAP and 1984787 - Installation notes
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
-    tune_page_cache_limit
     # SAP note 1984787 - Installation notes
     tune_uuidd_socket
 
@@ -27,7 +25,6 @@ start() {
 stop() {
     log "--- Going to revert BOBJ tuned parameters"
     revert_preparation
-    revert_page_cache_limit
     revert_uuidd_socket
 
     msgmni=$(restore_value kernel.msgmni)

--- a/profile/sap-hana/script.sh
+++ b/profile/sap-hana/script.sh
@@ -15,8 +15,6 @@ start() {
     log "--- Going to apply SAP tuning techniques"
     # Common tuning techniques apply to HANA and Netweaver
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
-    tune_page_cache_limit
     # SAP note 1984787 - Installation notes
     tune_uuidd_socket
 
@@ -98,7 +96,6 @@ stop() {
     log "--- Going to revert SAP tuned parameters"
 
     revert_preparation
-    revert_page_cache_limit
     revert_uuidd_socket
     #revert_shmmni
 

--- a/profile/sap-netweaver/script.sh
+++ b/profile/sap-netweaver/script.sh
@@ -15,8 +15,6 @@ start() {
     log "--- Going to apply SAP tuning techniques"
     # Common tuning techniques apply to HANA and Netweaver
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
-    tune_page_cache_limit
     # SAP note 1984787 - Installation notes
     tune_uuidd_socket
 
@@ -98,7 +96,6 @@ stop() {
     log "--- Going to revert SAP tuned parameters"
 
     revert_preparation
-    revert_page_cache_limit
     revert_uuidd_socket
     #revert_shmmni
 

--- a/sapconf.service
+++ b/sapconf.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=sapconf
+After=syslog.target systemd-sysctl.service network.target
+# SAP Note 1310037 (still valid)
+Wants=sysstat.service
+# Requested by https://bugzilla.suse.com/show_bug.cgi?id=983454 :
+# UUID should work properly (enabled) as soon as this package is installed.
+Requires=uuidd.socket
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStartPre=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) == "" ]]; then tuned-adm profile sap-netweaver &> /dev/null; fi'
+ExecStart=/bin/sh -c 'if ! /usr/bin/systemctl status tuned.service &> /dev/null; then /usr/bin/systemctl start tuned.service; fi'
+ExecReload=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) == sap-* ]]; then /usr/bin/systemctl restart tuned.service; fi'
+
+[Install]
+WantedBy=multi-user.target

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -235,44 +235,6 @@ NUMA_BALANCING=0
 #
 THP=never
 
-## Path:           SAP/Note/1557506 - Linux paging improvements
-## Description:    Tune page cache limit to prevent eviction of SAP applications
-##                 memory into swap
-## ServiceRestart: tuned
-
-# Consider to enable pagecache limit feature if your SAP workloads cause
-# frequent and excessive swapping activities.
-# It is recommended to leave pagecache limit disabled if the system has
-# low or no swap space.
-# Default is 'no'
-#
-# SAP Note 1557506
-#
-ENABLE_PAGECACHE_LIMIT="no"
-
-# vm.pagecache_limit_mb
-# When pagecache limit feature is enabled, the limit value has to set manually
-# by setting this parameter to the desired limit value.
-#
-# SAP Note 1557506
-#
-# Please uncomment the following line and set your preferred value
-#PAGECACHE_LIMIT_MB=""
-
-# vm.pagecache_limit_ignore_dirty
-# Whether or not to ignore dirty memory when enforcing the pagecache limit.
-# If set to 0, dirty memory will be freed (written onto disk) when enforcing
-# the pagecache limit.
-# If set to 1 (default), dirty memory will not be freed when enforcing the
-# pagecache limit.
-# If set to 2 - a middle ground, some dirty memory will be freed when enforcing
-# the limit.
-#
-# SAP Note 1557506
-#
-# Please uncomment the following line and set your preferred value
-#PAGECACHE_LIMIT_IGNORE_DIRTY=""
-
 
 ###############################################################################
 ###############################################################################


### PR DESCRIPTION
- remove left over pagecache limit references (bsc#1071539)
- add system unit file sapconf.service to start tuned, uuidd.socket
and sysstat during system boot and to restart tuned during
package update installation so that the changes will take effect
immediately (fate#325363)