### PR TITLE
activate the 'last used' sapconf profile during reboot, if availabe (…

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -43,7 +43,9 @@ case "$1" in
     # bsc#1026862
     #if [[ $(cat /etc/tuned/active_profile) != sap* ]]; then
     if [[ $(cat /etc/tuned/active_profile) == "" ]]; then
-      tuned-adm profile sap-netweaver &> /dev/null
+      profile=$(cat /var/lib/sapconf/last_profile 2> /dev/null)
+      profile=${profile:-sap-netweaver}
+      tuned-adm profile $profile &> /dev/null
     fi
     if ! systemctl status tuned &> /dev/null; then
       systemctl start tuned
@@ -109,6 +111,7 @@ case "$1" in
     # stop tuned and remove sapconf profile from active tuned profil
     if [[ $(cat /etc/tuned/active_profile) == sap-* ]]; then
         /usr/bin/systemctl stop tuned >/dev/null 2>&1
+        cat /etc/tuned/active_profile > /var/lib/sapconf/last_profile
         > /etc/tuned/active_profile
         systemctl status tuned &> /dev/null && exit 1
     fi

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -60,7 +60,7 @@ systemctl start sapconf.service
 At the moment we're providing the following pre\-defined profiles:
 .TP
 .BI "sap\-netweaver"
-Tuning profile for SAP NetWeaver. It is the default profile. If the tune daemon does not have any profile active, \fBsapconf(8)\fR will activiate SAP NetWeaver tuning profile during start.
+Tuning profile for SAP NetWeaver. It is the default profile. If the tune daemon does not have any profile active and there is no information about the last used sapconf profile available in \fI/var/lib/sapconf/last_profile\fR, \fBsapconf(8)\fR will activiate SAP NetWeaver tuning profile during start.
 See the man page \fBtuned-profiles-sap-netweaver(7)\fR for details.
 .br
 To get a better base in the future for mixed HANA and ABAB workloads on one system, sapconf will use the same tuning values for HANA and NetWeaver workloads. That means the use of the same tuned.conf and script.sh file for both profiles
@@ -151,6 +151,11 @@ profile special configuration file
 A description of the used values can be found at the end of the central configuration file \fI/etc/sysconfig/sapconf\fR
 .br
 The profiles are stored in subdirectories below \fI/usr/lib/tuned\fP. If you need to customize the profiles, you can copy them to \fI/etc/tuned\fP and modify them as you need. When loading profiles with the same name, the /etc/tuned takes precedence. In such case you will not lose your customized profiles between tuned updates.
+.RE
+.PP
+\fI/var/lib/sapconf/last_profile\fR
+.RS 4
+contains the last used sapconf profile. The file will be written during stop of the sapconf service and the content will be used during start of the sapconf service.
 .RE
 .PP
 \fI/var/log/sapconf\.log\fR

--- a/man/sapconf.8
+++ b/man/sapconf.8
@@ -27,7 +27,7 @@ sapconf activates SAP NetWeaver, SAP ASE/Sybase, SAP Business OBJects (BOBJ) or 
 .SH ACTIONS
 
 .IP \[bu]
-start,restart,try-restart - If the tune daemon does not have any profile active, activiate SAP NetWeaver tuning profile. Otherwise leave the profile choice alone and activate tune daemon.
+start,restart,try-restart - If the tune daemon does not have any profile active and there is no information about the last used sapconf profile available in \fI/var/lib/sapconf/last_profile\fR, activate SAP NetWeaver tuning profile. Otherwise leave the profile choice alone and activate tune daemon.
 
 .IP \[bu]
 reload - If the current tuned profile is a sapconf profile, restart the tuned service.
@@ -45,7 +45,7 @@ ase,sybase - Activate SAP ASE (Sybase) tuning profile. Exit 1 on failure.
 bobj - Activate SAP Business OBJects (BOBJ) tuning profile. Exit 1 on failure.
 
 .IP \[bu]
-stop - If the current tuned profile is a sapconf profile, stop the tune daemon and remove the sapconf profile from the active tuned profile file.
+stop - If the current tuned profile is a sapconf profile, stop the tune daemon, write the current sapconf profile to \fI/var/lib/sapconf/last_profile\fR and remove the sapconf profile from the active tuned profile file.
 
 .IP \[bu]
 status - Report the status of tune daemon. Exit 1 on failure.


### PR DESCRIPTION
…bsc#1091030)

To fix the problem of bsc#1091030,  save the current used sapconf profile during stop of the sapconf service. When the system is coming up again and the sapconf service is enabled, the stored 'last used' sapconf profile will be used to set the active tuned profile before starting the tune daemon. If there is no 'last used' sapconf profile the default profile 'sap-netweaver' will be used as active tuned profile.
If there is a non-sapconf profile set (e.g. balanced or saptune) during the reboot of the system the problem does not occur. And SLE15 does not have the problem, because there is only one sapconf profile available.

Please review and merge. I plan to do the MRs for SLE12SP1/SP2/SP3 on Monday and will improve the sapconf-test scripts to catch this case as well.
