### PR TITLE
enable shellcheck tests on travis CI. A very nice check tool.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: bash
+sudo: false
+script:
+  - find . -type f -exec awk ' /^#!.*bash/{print FILENAME} {nextfile}' {} + | xargs shellcheck -s bash
+  #- ./ci/build.sh
+notifications:
+email: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/SUSE/sapconf.svg?branch=master)](https://travis-ci.org/SUSE/sapconf)
+
 # sapconf
 The utility adjusts operating system parameters, such as kernel tuning settings and resource limits, to allow running various SAP solutions at satisfactory performance.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/SUSE/sapconf.svg?branch=master)](https://travis-ci.org/SUSE/sapconf)
+[![Build Status](https://travis-ci.org/SUSE/sapconf.svg?branch=sle-12)](https://travis-ci.org/SUSE/sapconf)
 
 # sapconf
 The utility adjusts operating system parameters, such as kernel tuning settings and resource limits, to allow running various SAP solutions at satisfactory performance.

--- a/bin/SAPconf
+++ b/bin/SAPconf
@@ -19,4 +19,4 @@
 # Therefore, this program calls sapconf with action "start" to trigger
 # activation of SAP NetWeaver tuning profile.
 
-exec -a $0 /usr/sbin/sapconf start
+exec -a "$0" /usr/sbin/sapconf start

--- a/bin/sapconf
+++ b/bin/sapconf
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2188
+
 #
 # /usr/sbin/sapconf
 #
@@ -45,7 +47,7 @@ case "$1" in
     if [[ $(cat /etc/tuned/active_profile) == "" ]]; then
       profile=$(cat /var/lib/sapconf/last_profile 2> /dev/null)
       profile=${profile:-sap-netweaver}
-      tuned-adm profile $profile &> /dev/null
+      tuned-adm profile "$profile" &> /dev/null
     fi
     if ! systemctl status tuned &> /dev/null; then
       systemctl start tuned

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 
 # common.sh implements common tuning techniques that are universally applied to many SAP softwares.
 # Authors:
@@ -17,6 +18,10 @@ tune_preparation() {
     # VSZ_TMPFS_PERCENT is by default 75, sysconfig file may override this value.
     declare VSZ_TMPFS_PERCENT=75
     declare TMPFS_SIZE_REQ=0
+    VSZ_tmp=$(awk -v t=0 '/^(Mem|Swap)Total:/ {t+=$2} END {print t}' < /proc/meminfo) # total (system+swap) memory size in KB
+    declare -r VSZ=$VSZ_tmp
+    declare TMPFS_OPTS
+    declare TMPFS_SIZE
 
     # semaphore variables
     declare SEMMSLCUR
@@ -24,7 +29,7 @@ tune_preparation() {
     declare SEMOPMCUR
     declare SEMMNICUR
 
-    # Read minimal value requirements from sysconfig, the declarations will set variables above.
+    # Read value requirements from sysconfig, the declarations will set variables above.
     if [ -r /etc/sysconfig/sapconf ]; then
         source /etc/sysconfig/sapconf
     else
@@ -36,71 +41,72 @@ tune_preparation() {
     # should rewrite variable names. But....
     for par in SHMALL_MIN SHMMAX_MIN SEMMSL_MIN SEMMNS_MIN SEMOPM_MIN SEMMNI_MIN MAX_MAP_COUNT_DEF SHMMNI_DEF DIRTY_BYTES_DEF DIRTY_BG_BYTES_DEF; do
         npar=${par%_*}
-        if [ -n "$par" -a -z "$npar" ]; then
+        if [ -n "${!par}" ] && [ -z "${!npar}" ]; then
             # the only interesting case:
-            # the old variable name is declared in the sysconfig file, but the
+            # the old variable name is declared in the sysconfig file, but
             # NOT the new variable name
             # So set the new variable name  with the value of the old one
             declare $npar=${!par}
         fi
     done
 
-    # Collect current information
+    ## Collect current information
 
     # semaphore settings
     read -r SEMMSLCUR SEMMNSCUR SEMOPMCUR SEMMNICUR < <(sysctl -n kernel.sem)
     # Mount - tmpfs mount options and size
-    declare TMPFS_OPTS
-    read discard discard discard TMPFS_OPTS discard < <(grep -E '^tmpfs /dev/shm .+' /proc/mounts)
+    # disable shell check for variable 'discard'
+    # shellcheck disable=SC2034
+    read -r discard discard discard TMPFS_OPTS discard < <(grep -E '^tmpfs /dev/shm .+' /proc/mounts)
     if [ ! "$TMPFS_OPTS" ]; then
         log "The system does not use tmpfs. Please configure tmpfs and try again."
         exit 1
     fi
     # Remove size= from mount options
-    declare TMPFS_OPTS=$(echo "$TMPFS_OPTS" | sed 's/size=[^,]\+//' | sed 's/^,//' | sed 's/,$//' | sed 's/,,/,/')
-    declare TMPFS_SIZE=$(($(stat -fc '(%b*%S)>>10' /dev/shm))) # in KBytes
+    TMPFS_OPTS=$(echo "$TMPFS_OPTS" | sed 's/size=[^,]\+//' | sed 's/^,//' | sed 's/,$//' | sed 's/,,/,/')
+    TMPFS_SIZE=$(($(stat -fc '(%b*%S)>>10' /dev/shm))) # in KBytes
 
-    # Calculate recommended value
+    ## Calculate recommended value
 
     # 1275776 - Preparing SLES for SAP
-    declare -r VSZ=$(awk -v t=0 '/^(Mem|Swap)Total:/ {t+=$2} END {print t}' < /proc/meminfo) # total (system+swap) memory size in KB
-    declare -r PSZ=$(getconf PAGESIZE)
-    declare TMPFS_SIZE_REQ=$(math "$VSZ*$VSZ_TMPFS_PERCENT/100")
+    TMPFS_SIZE_REQ=$(math "$VSZ*$VSZ_TMPFS_PERCENT/100")
 
-    # Apply new parameters
+    ## Apply new parameters
 
     # Enlarge tmpfs
-    if [ $(math_test "$TMPFS_SIZE_REQ > $TMPFS_SIZE") ]; then
+    if [ "$(math_test "$TMPFS_SIZE_REQ > $TMPFS_SIZE")" ]; then
         log "Increasing size of /dev/shm from $TMPFS_SIZE to $TMPFS_SIZE_REQ"
         save_value tmpfs.size "$TMPFS_SIZE"
         save_value tmpfs.mount_opts "$TMPFS_OPTS"
         mount -o "remount,${TMPFS_OPTS},size=${TMPFS_SIZE_REQ}k" /dev/shm
-    elif [ $(math_test "$TMPFS_SIZE_REQ <= $TMPFS_SIZE") ]; then
+    elif [ "$(math_test "$TMPFS_SIZE_REQ <= $TMPFS_SIZE")" ]; then
         log "Leaving size of /dev/shm untouched at $TMPFS_SIZE"
     fi
     # Tweak shm
-    save_value kernel.shmmax $(sysctl -n kernel.shmmax)
+    save_value kernel.shmmax "$(sysctl -n kernel.shmmax)"
     chk_and_set_conf_val SHMMAX kernel.shmmax
-    save_value kernel.shmall $(sysctl -n kernel.shmall)
+    save_value kernel.shmall "$(sysctl -n kernel.shmall)"
     chk_and_set_conf_val SHMALL kernel.shmall
     # Tweak semaphore
-    save_value kernel.sem "$(sysctl -n kernel.sem)"
-    SEMMSL=$(chk_conf_val SEMMSL $SEMMSLCUR)
-    SEMMNS=$(chk_conf_val SEMMNS $SEMMNSCUR)
-    SEMOPM=$(chk_conf_val SEMOPM $SEMOPMCUR)
-    SEMMNI=$(chk_conf_val SEMMNI $SEMMNICUR)
-    log "Set kernel.sem to '$SEMMSL $SEMMNS $SEMOPM $SEMMNI'"
-    sysctl -w "kernel.sem=$SEMMSL $SEMMNS $SEMOPM $SEMMNI"
+    SEMMSL=$(chk_conf_val SEMMSL "$SEMMSLCUR")
+    SEMMNS=$(chk_conf_val SEMMNS "$SEMMNSCUR")
+    SEMOPM=$(chk_conf_val SEMOPM "$SEMOPMCUR")
+    SEMMNI=$(chk_conf_val SEMMNI "$SEMMNICUR")
+    if [ "$SEMMSLCUR $SEMMNSCUR $SEMOPMCUR $SEMMNICUR" != "$SEMMSL $SEMMNS $SEMOPM $SEMMNI" ]; then
+        save_value kernel.sem "$(sysctl -n kernel.sem)"
+        log "Change kernel.sem from '$SEMMSLCUR $SEMMNSCUR $SEMOPMCUR $SEMMNICUR' to '$SEMMSL $SEMMNS $SEMOPM $SEMMNI'"
+        sysctl -w "kernel.sem=$SEMMSL $SEMMNS $SEMOPM $SEMMNI"
+    else
+        log "Leaving kernel.sem unchanged at '$SEMMSLCUR $SEMMNSCUR $SEMOPMCUR $SEMMNICUR'"
+    fi
     # Tweak max_map_count
-    save_value vm.max_map_count $(sysctl -n vm.max_map_count)
+    save_value vm.max_map_count "$(sysctl -n vm.max_map_count)"
     chk_and_set_conf_val MAX_MAP_COUNT vm.max_map_count
 
     # Tune ulimits for the max number of open files (rollback is not necessary in revert function)
     all_nofile_limits=""
-    # keep syntax checker happy, otherwise checker complains that LIMIT_ is undefined in the next line.
-    declare LIMIT_
     for limit in ${!LIMIT_*}; do # LIMIT_ parameters are defined in sysconfig file
-        all_nofile_limits="$all_nofile_limits\n${!limit}"
+        all_nofile_limits="$all_nofile_limits\\n${!limit}"
     done
     for ulimit_group in @sapsys @sdba @dba; do
         for ulimit_type in soft hard; do
@@ -137,7 +143,7 @@ revert_preparation() {
     # Restore the size of tmpfs
     TMPFS_SIZE=$(restore_value tmpfs.size)
     TMPFS_OPTS=$(restore_value tmpfs.mount_opts)
-    [ "$TMPFS_SIZE" -a -e /dev/shm ] && mount -o "remount,${TMPFS_OPTS},size=${TMPFS_SIZE}k" /dev/shm
+    [ "$TMPFS_SIZE" ] && [ -e /dev/shm ] && mount -o "remount,${TMPFS_OPTS},size=${TMPFS_SIZE}k" /dev/shm
     log "--- Finished reverting universally tuned parameters"
 }
 
@@ -159,7 +165,7 @@ tune_page_cache_limit() {
                 log "Disabling page cache limit"
                 PAGECACHE_LIMIT_MB="0"
         fi
-        save_value vm.pagecache_limit_mb $(sysctl -n vm.pagecache_limit_mb)
+        save_value vm.pagecache_limit_mb "$(sysctl -n vm.pagecache_limit_mb)"
         log "Setting vm.pagecache_limit_mb=$PAGECACHE_LIMIT_MB"
         sysctl -w "vm.pagecache_limit_mb=$PAGECACHE_LIMIT_MB"
         if [ -z "$PAGECACHE_LIMIT_IGNORE_DIRTY" ]; then
@@ -168,12 +174,12 @@ tune_page_cache_limit() {
                 PAGECACHE_LIMIT_IGNORE_DIRTY="0"
         fi
         # Set ignore_dirty
-        save_value vm.pagecache_limit_ignore_dirty $(sysctl -n vm.pagecache_limit_ignore_dirty)
+        save_value vm.pagecache_limit_ignore_dirty "$(sysctl -n vm.pagecache_limit_ignore_dirty)"
         log "Setting vm.pagecache_limit_ignore_dirty=$PAGECACHE_LIMIT_IGNORE_DIRTY"
         sysctl -w "vm.pagecache_limit_ignore_dirty=$PAGECACHE_LIMIT_IGNORE_DIRTY"
     else
         # Disable pagecache limit by setting it to 0
-        save_value vm.pagecache_limit_mb $(sysctl -n vm.pagecache_limit_mb)
+        save_value vm.pagecache_limit_mb "$(sysctl -n vm.pagecache_limit_mb)"
         log "Disabling page cache limit"
         sysctl -w "vm.pagecache_limit_mb=0"
     fi

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
+
 # util.sh provides utility functions to assist in calculating and applying tuned parameters
 
 # math invokes arbitrary precision calculator "bc" to work on a formula, and then returns the result.
 math() {
-    echo $* | bc | tr -d '\n'
+    echo "$@" | bc | tr -d '\n'
 }
 
 # math_test invokes arbitrary precision calculator "bc" to work on a math comparison formula.
 # Returns "1" if formula evaluates to true, otherwise it returns an empty string.
 math_test() {
-    [ $(echo $* | bc | tr -d '\n') = '1' ] && echo -n 1
+    [ "$(echo "$@" | bc | tr -d '\n')" = '1' ] && echo -n 1
 }
 
 # log prints a log message into standard output and appends it to /var/log/sapconf.
 log() {
-    declare -r msg=$(echo $(date --rfc-3339=seconds) ' ' $*)
+    declare msg
+    msg="$(date --rfc-3339=seconds)   $*"
     # Give log message to standard error so that:
     # it enjoys unbuffered output;
     # a function that uses "echo" to make return value will not be affected by log output
@@ -29,13 +32,14 @@ log() {
 increase_sysctl() {
     declare -r param=$1
     declare -r new_val=$2
-    declare -r current_val=$(sysctl -n "$param")
-    if [ $(math_test "$current_val < $new_val") ]; then
+    cur_val=$(sysctl -n "$param")
+    declare -r current_val=$cur_val
+    if [ "$(math_test "$current_val < $new_val")" ]; then
         log "Increasing $param from $current_val to $new_val"
         sysctl -w "$param=$new_val"
         echo -n "$new_val"
     else
-        if [ $(math_test "$current_val > $new_val") ]; then
+        if [ "$(math_test "$current_val > $new_val")" ]; then
             log "Leaving $param unchanged at $current_val instead of calculated $new_val"
         else
             log "Leaving $param unchanged at $current_val"
@@ -50,11 +54,11 @@ increase_val() {
     declare -r remark=$1
     declare -r current_val=$2
     declare -r new_val=$3
-    if [ $(math_test "$current_val < $new_val") ]; then
+    if [ "$(math_test "$current_val < $new_val")" ]; then
         log "Increasing $remark from $current_val to $new_val"
         echo -n "$new_val"
     else
-        if [ $(math_test "$current_val > $new_val") ]; then
+        if [ "$(math_test "$current_val > $new_val")" ]; then
             log "Leaving $remark unchanged at $current_val instead of $new_val"
         else
             log "Leaving $remark unchanged at $current_val"
@@ -71,29 +75,28 @@ chk_conf_val() {
     val2set=${!val2chk}
     if [ -z "$val2set" ]; then
         log "ATTENTION: $val2chk not set in sysconfig file."
-        log "Setting default value '$def_val' instead"
-	echo -n "$def_val"
+        echo -n "$def_val"
     else
-	echo -n "$val2set"
+        echo -n "$val2set"
     fi
 }
 
 # check, if a value is defined in the (sourced) sysconfig file
 # if not, log a warning and leave the current system value unchanged
 # otherwise set the value from sysconfig file as the new system value
-chk_and_set_conf_val() { 
+chk_and_set_conf_val() {
     declare -r val2chk=$1
-    declare -r param=$2 
+    declare -r param=$2
     val2set=${!val2chk}
-    current_val=$(sysctl -n $param)
+    current_val=$(sysctl -n "$param")
     if [ -z "$val2set" ]; then
         log "ATTENTION: $val2chk not set in sysconfig file."
         log "Leaving $param unchanged at $current_val"
     else
-        if [ $(math_test "$current_val < $val2set") ]; then
+        if [ "$(math_test "$current_val < $val2set")" ]; then
             log "Increasing $param from $current_val to $val2set"
             sysctl -w "$param=$val2set"
-        elif [ $(math_test "$current_val > $val2set") ]; then
+        elif [ "$(math_test "$current_val > $val2set")" ]; then
             log "Decreasing $param from $current_val to $val2set"
             sysctl -w "$param=$val2set"
         else

--- a/profile/sap-bobj/script.sh
+++ b/profile/sap-bobj/script.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC1091,SC2068
+
 # Optimise kernel parameters for running SAP BOBJ
 
 cd /usr/lib/sapconf || exit 1
@@ -14,11 +16,13 @@ start() {
     # SAP note 1984787 - Installation notes
     tune_uuidd_socket
 
-    save_value kernel.msgmni $(sysctl -n kernel.msgmni)
+    save_value kernel.msgmni "$(sysctl -n kernel.msgmni)"
+    # shellcheck disable=SC2034
     MSGMNI=1024
     chk_and_set_conf_val MSGMNI kernel.msgmni
 
-    save_value kernel.shmmax $(sysctl -n kernel.shmmax)
+    save_value kernel.shmmax "$(sysctl -n kernel.shmmax)"
+    # shellcheck disable=SC2034
     SHMMAX=18446744073709551615
     chk_and_set_conf_val SHMMAX kernel.shmmax
 
@@ -32,10 +36,10 @@ stop() {
     revert_page_cache_limit
     revert_uuidd_socket
 
-    msgmni=$(restore_value kernel.msgmni)
+    msgmni="$(restore_value kernel.msgmni)"
     [ "$msgmni" ] && log "Restoring kernel.msgmni=$msgmni" && sysctl -w "kernel.msgmni=$msgmni"
 
-    shmmax=$(restore_value kernel.shmmax)
+    shmmax="$(restore_value kernel.shmmax)"
     [ "$shmmax" ] && log "Restoring kernel.shmmax=$shmmax" && sysctl -w "kernel.shmmax=$shmmax"
 
     log "--- Finished reverting BOBJ tuned parameters"

--- a/sysconfig/sapnote-1680803
+++ b/sysconfig/sapnote-1680803
@@ -8,3 +8,67 @@ NRREQ=1024
 # memlock for user sybase
 # Default: 0 (which means calculation: RAM in KB - 10%)
 MEMLOCK=0
+
+# kernel.shmmni
+# The value is the maximum number of shared memory identifies available in the
+# system.
+# kernel.shmmni is set to the SHMMNI value from this file
+# kernel.shmmni should be set to 32768 (see bsc#874778)
+# bsc#874778
+SHMMNI=32768
+
+
+# from SAP-Note 1410736
+# The tcp_keepalive_time option will determine how long an inactive established
+# connection will be maintained.
+# The default value is 7200 seconds which is quite large and the server might
+# end up running off resources if there are just too many requests coming in.
+# It would be good to reduce it to much lower value.
+# The tcp_keepalive_intvl parameter allows you to control the interval you want
+# to send the keep alive probe.
+# By default in SLES this interval period is every 75 seconds which is very high
+# as it would be more than 4 minutes for your server to see the connection has
+# failed.
+# net.ipv4.tcp_keepalive_time
+KEEPALIVETIME=300
+# net.ipv4.tcp_keepalive_intvl
+KEEPALIVEINTVL=300
+
+# maximum number of asynchronous I/Os.
+# fs.aio-max-nr
+AIOMAXNR=1048576
+
+# Increase system file descriptor limit
+# fs.file-max
+FILEMAX=6291456
+
+# Increase Linux autotuning TCP buffer limits
+# Linux kernel allocates socket for every network connection that takes place.
+# The socket are two ends of communication channel, every socket has a receive
+# and send buffer which is also known as receive and write buffer. As these
+# buffers get full, it does not accept any more data. As a result no new data
+# can be processed and packets tend to get dropped.
+# You may benefit from changing the values of
+# net.core.rmem_max, net.core.wmem_max
+# net.core.rmem_default, net.core.wmem_default
+# Set max to 16MB (16777216) for 1GE and 32M (33554432) or 54M (56623104) for 10GE
+# Don't set tcp_mem itself! Let the kernel scale it based on RAM.
+RMEMMAX=16777216
+WMEMMAX=16777216
+RMEMDEF=16777216
+WMEMDEF=16777216
+
+# Increase the max packet backlog
+# net.core.netdev_max_backlog
+NETDEVMAXBACKLOG=30000
+
+# If the server is a heavily used application server, e.g. a Database, it would
+# benefit significantly by using Huge Pages.
+# The default size of Huge Page in SLES is 2 MB, enabling Huge Pages would aid
+# in significant improvements for Memory Intensive Applications/Databases,
+# HPC Machines, this configuration needs to be done if the Applications support
+# Huge Pages. If the Applications do not support Huge Pages then configuring
+# Huge Pages would result in wastage of memory as it cannot be used any further
+# by the OS, by Default no huge pages are allocated.
+# When enabled, kernel parameter "vm.nr_hugepages" will be raised to 128.
+NUMBER_HUGEPAGES=128


### PR DESCRIPTION
Change the shell scripts to fullfill the shellcheck requirement.
Consolidate all ASE related sapconf configuration settings into the ASE configuration file /etc/sysconfig/sapnote-1680803. On the analogy of bsc#1070508 and it was the simplest and savest way to fit the shellcheck test SC2034.
Found 1 real error and 1 miss in my coding (a realy rarly used condition) during the tests of the shellcheck changes.
Improve the log messages for the kernel.sem settings