### PR TITLE
correct the SAP Note references in the man pages and in the sysconfig…

### DIFF
--- a/lib/sccu.sh
+++ b/lib/sccu.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1004
+
+# sapconf comment update script
+# sccu.sh is called by post script of sapconf package installation to 
+# update the comment sections in the /etc/sysconfig/sapconf file
+# which is impossible by using /bin/fillup
+
+SN=/etc/sysconfig/sapconf
+# change commented variables so that fillup will preserve the trailing comments
+sed -i 's/\(^#.*\)=""$/\1 = ""/' $SN
+
+# change comments as requested in bsc#1096496
+if ! (grep "^# SCCU1$" $SN >/dev/null 2>&1); then
+    sed -i '/^# SAP Note$/{N;d}' $SN
+    sed -i 's/SAP Note 1275776,/SAP Note 1980196,/' $SN
+    sed -i 's/SAP Note 1275776/SAP Note 1984787/' $SN
+    sed -i 's/SAP Note 1310037/SAP Note 1984787/' $SN
+    sed -i 's/ (see bsc#874778)//' $SN
+    sed -i 's/ bsc#874778,//' $SN
+    sed -i 's/^# TID_7010287$/# SAP Note 1984787, SAP Note 1557506/' $SN
+    sed -i '/^# set net.ipv4.tcp_slow_start_after_idle=0/a\
+#\
+# SAP Note 2382421\
+#' $SN
+    sed -i '/^# scheduler.$/a\
+#\
+# SAP Note 1984787' $SN
+    sed -i '/^#min_perf_pct = 100$/i\
+# SAP Note 2205917\
+#' $SN
+    sed -i '/^#SAPCONF_END/i\
+# SCCU1' $SN
+fi

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "April 2018" "sapconf configuration file"
+.TH sapconf 5 "June 2018" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -90,7 +90,7 @@ The lower tuning limit of maxium total number of semaphore sets.
 .PP
 Semaphore limits, set in the common part (tune_preparation) of the scripting
 .br
-SAP Note 1275776
+SAP Note 1984787
 .RE
 .PP
 \fBLIMIT_1="@sapsys soft nofile 65536"\fP
@@ -128,7 +128,7 @@ MAX_MAP_COUNT set to MAX_INT (2147483647)
 .RS 4
 Memory Management setting in the common part (tune_preparation) of the scripting
 .br
-SAP Note 1275776, 900929, HANA Administration Guide
+SAP Note 1980196, 900929, HANA Administration Guide
 .RE
 .PP
 .TP 4
@@ -140,7 +140,7 @@ The value is the maximum number of shared memory identifies available in the sys
 .RS 4
 Linux kernel setting, set in the profile specific part of the scripting
 .br
-SAP Note 2534844, bsc#874778, HANA Administration Guide
+SAP Note 2534844, HANA Administration Guide
 .RE
 .PP
 .TP 4
@@ -158,7 +158,7 @@ Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any val
 .RS 4
 Memory Management setting in the profile specific part of the scripting
 .br
-TID_7010287
+SAP Note 1984787, SAP Note 1557506
 .RE
 .PP
 .TP 4
@@ -174,7 +174,7 @@ Note: when changing the tuned profile or switching off tuned, both values will b
 .RS 4
 Memory Management setting in the profile specific part of the scripting
 .br
-TID_7010287
+SAP Note 1984787, SAP Note 1557506
 .RE
 .PP
 .TP 4
@@ -186,7 +186,7 @@ This value is important for large ScaleOut HANA clusters and HANA2 in general. S
 .RS 4
 IO related setting \fBnet.ipv4.tcp_slow_start_after_idle\fP during the profile specific part of the scripting
 .br
-SAP Note 
+SAP Note 2382421
 .RE
 .PP
 .TP 4
@@ -335,7 +335,7 @@ The value is commented out by default
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note
+SAP Note 2205917
 .RE
 .PP
 .TP 4
@@ -351,7 +351,7 @@ When set, all block devices on the system will be switched to the chosen schedul
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note
+SAP Note 1984787
 .RE
 .PP
 .SH DESCRIPTION OF PART 3
@@ -362,7 +362,7 @@ These values are profile independent. They describe requirements and settings du
 .BI sysstat
 Package requirement. The service is started after installation of the package.
 .br
-SAP Note 1310037
+SAP Note 1984787
 .PP
 .TP 4
 .BI uuidd.socket

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 8 "April 2018" "util-linux" "System Administration"
+.TH sapconf 8 "June 2018" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -80,7 +80,7 @@ Profile for SAP ASE (Sybase) tuning. See the man page \fBtuned-profiles-sap-ase(
 Profile for SAP Business OBJects (BOBJ) tuning. See the man page \fBtuned-profiles-sap-bobj(7)\fR for details.
 
 .SH "SAP NOTES"
-All settings are done according to SAP note number 900929, 941735, 1275776, 1310037, 1557506, 1771258, 1984787, 2031375, 2055470, 2131662, 2205917, 2534844 and TID_7010287
+All settings are done according to SAP note number 900929, 941735, 1557506, 1771258, 1980196, 1984787, 2031375, 2055470, 2131662, 2205917, 2382421 and 2534844
 .br
 See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR or \fBsapconf(5)\fP for details.
 
@@ -88,7 +88,7 @@ See the comments in the central sapconf configuration file \fI/etc/sysconfig/sap
 The following package requirements exist for the sapconf package:
 .TP 4
 .BI "sysstat" 
-service is started after package installation (see SAP Note 1310037)
+service is started after package installation (see SAP Note 1984787)
 .PP
 .TP 4
 .BI "uuidd.socket"

--- a/man/tuned-profiles-sap-hana.7
+++ b/man/tuned-profiles-sap-hana.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH TUNED_PROFILES_SAP_HANA "7" "April 2018" "Adaptive system tuning daemon" "tuned"
+.TH TUNED_PROFILES_SAP_HANA "7" "June 2018" "Adaptive system tuning daemon" "tuned"
 .SH NAME
 tuned\-profiles\-sap\-hana - Tuning profile for SAP HANA and Business One.
 
@@ -55,7 +55,7 @@ Note that
 use the same tuning values for HANA and NetWeaver workloads to get a better base in the future for mixed HANA and ABAB workloads on one system. That means the use of the same tuned.conf and script.sh file for both profiles. 
 
 .SH "SAP NOTES"
-The tuned parameters are calculated according to SAP note number 900929, 941735, 1275776, 1310037, 1557506, 1771258, 1984787, 2031375, 2055470, 2131662, 2205917, 2534844 and TID_7010287
+The tuned parameters are calculated according to SAP note number 900929, 941735, 1557506, 1771258, 1980196, 1984787, 2031375, 2055470, 2131662, 2205917, 2382421 and 2534844
 .br See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR for details.
 
 

--- a/man/tuned-profiles-sap-netweaver.7
+++ b/man/tuned-profiles-sap-netweaver.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH TUNED_PROFILES_SAP_NETWEAVER "7" "April 2018" "Adaptive system tuning daemon" "tuned"
+.TH TUNED_PROFILES_SAP_NETWEAVER "7" "June 2018" "Adaptive system tuning daemon" "tuned"
 .SH NAME
 tuned\-profiles\-sap\-netweaver - Tuning profile for SAP NetWeaver.
 
@@ -55,7 +55,7 @@ Note that
 use the same tuning values for HANA and NetWeaver workloads to get a better base in the future for mixed HANA and ABAB workloads on one system. That means the use of the same tuned.conf and script.sh file for both profiles. 
 
 .SH "SAP NOTES"
-The tuned parameters are calculated according to SAP note number 900929, 941735, 1275776, 1310037, 1557506, 1771258, 1984787, 2031375, 2055470, 2131662, 2205917, 2534844 and TID_7010287
+The tuned parameters are calculated according to SAP note number 900929, 941735, 1557506, 1771258, 1980196, 1984787, 2031375, 2055470, 2131662, 2205917, 2382421 and 2534844
 .br See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR for details.
 
 

--- a/profile/sap-ase/script.sh
+++ b/profile/sap-ase/script.sh
@@ -56,7 +56,6 @@ start() {
         save_value "memlock_$ulimit_type" "$save_limit"
     done
 
-
     # 1410736
     save_value net.ipv4.tcp_keepalive_time "$(sysctl -n net.ipv4.tcp_keepalive_time)"
     chk_and_set_conf_val KEEPALIVETIME net.ipv4.tcp_keepalive_time
@@ -83,24 +82,9 @@ start() {
     save_value net.core.netdev_max_backlog "$(sysctl -n net.core.netdev_max_backlog)"
     chk_and_set_conf_val NETDEVMAXBACKLOG net.core.netdev_max_backlog
 
-    # If the server is a heavily used application server, e.g. a Database, it would
-    # benefit significantly by using Huge Pages.
-    # The default size of Huge Page in SLES is 2 MB, enabling Huge Pages would aid
-    # in significant improvements for Memory Intensive Applications/Databases,
-    # HPC Machines, this configuration needs to be done if the Applications support
-    # Huge Pages. If the Applications do not support Huge Pages then configuring
-    # Huge Pages would result in wastage of memory as it cannot be used any further
-    # by the OS.
+    # Huge Pages - vm.nr_hugepages
     save_value vm.nr_hugepages "$(sysctl -n vm.nr_hugepages)"
     chk_and_set_conf_val NUMBER_HUGEPAGES vm.nr_hugepages
-
-    # The following parameters were specified in tuned.conf before 2017-07-25, but are removed from tuned.conf
-    # because they are redundant or no formula exists to calculate them automatically:
-    # vm.dirty_ratio = 10
-    # vm.dirty_background_ratio = 3
-    # kernel.sem = 1250 256000 100 8192
-    # kernel.sched_min_granularity_ns = 10000000
-    # kernel.sched_wakeup_granularity_ns = 15000000
 
     log "--- Finished application of ASE tuning techniques"
     return 0
@@ -110,7 +94,6 @@ stop() {
     log "--- Going to revert ASE tuned parameters"
     revert_preparation
     revert_page_cache_limit
-    revert_uuidd_socket
     revert_shmmni
 
     val=$(restore_value net.ipv4.tcp_keepalive_time)
@@ -122,7 +105,6 @@ stop() {
     [ "$val" ] && log "Restoring fs.aio-max-nr=$val" && sysctl -w "fs.aio-max-nr=$val"
     val=$(restore_value fs.file-max)
     [ "$val" ] && log "Restoring fs.file-max=$val" && sysctl -w "fs.file-max=$val"
-
 
     val=$(restore_value net.core.rmem_max)
     [ "$val" ] && log "Restoring net.core.rmem_max=$val" && sysctl -w "net.core.rmem_max=$val"

--- a/profile/sap-bobj/script.sh
+++ b/profile/sap-bobj/script.sh
@@ -34,7 +34,6 @@ stop() {
     log "--- Going to revert BOBJ tuned parameters"
     revert_preparation
     revert_page_cache_limit
-    revert_uuidd_socket
 
     msgmni="$(restore_value kernel.msgmni)"
     [ "$msgmni" ] && log "Restoring kernel.msgmni=$msgmni" && sysctl -w "kernel.msgmni=$msgmni"

--- a/profile/sap-hana/script.sh
+++ b/profile/sap-hana/script.sh
@@ -4,7 +4,7 @@
 # Optimise kernel parameters for running SAP HANA and HANA based products (such as Business One).
 # The calculations are based on:
 # - Parameters tuned by SAP installation wizard and configure_HANA.sh.
-# - Various SAP notes.
+# - Various SAP Notes.
 # Authors:
 #   Angela Briel <abriel@suse.com>
 #   Howard Guo <hguo@suse.com>
@@ -17,9 +17,9 @@ start() {
     log "--- Going to apply SAP tuning techniques"
     # Common tuning techniques apply to HANA and NetWeaver
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
+    # SAP Note 1557506 - Linux paging improvements
     tune_page_cache_limit
-    # SAP note 1984787 - Installation notes
+    # SAP Note 1984787 - Installation notes
     tune_uuidd_socket
 
     # Read value requirements from sysconfig
@@ -45,11 +45,11 @@ start() {
         fi
     done
 
-    # SAP Note 2534844, bsc#874778
+    # SAP Note 2534844
     save_value kernel.shmmni "$(sysctl -n kernel.shmmni)"
     chk_and_set_conf_val SHMMNI kernel.shmmni
 
-    # TID_7010287
+    # SAP Note 1984787
     save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
     save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
     chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
@@ -57,7 +57,7 @@ start() {
     save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
     chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
 
-    # SAP note
+    # SAP Note 2382421
     cur_val=$(sysctl -n net.ipv4.tcp_slow_start_after_idle)
     TCP_SLOW_START=$(chk_conf_val TCP_SLOW_START "$cur_val")
     if [ "$cur_val" != "$TCP_SLOW_START" ]; then
@@ -68,7 +68,7 @@ start() {
         log "Leaving net.ipv4.tcp_slow_start_after_idle unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - KSM and AutoNUMA both should be off
+    # SAP Note 2205917 - KSM and AutoNUMA both should be off
     cur_val=$(cat /sys/kernel/mm/ksm/run)
     KSM=$(chk_conf_val KSM "$cur_val")
     if [ "$cur_val" != "$KSM" ]; then
@@ -88,8 +88,8 @@ start() {
         log "Leaving numa_balancing unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - Transparent Hugepage should be never
-    # SAP note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
+    # SAP Note 2205917 - Transparent Hugepage should be never
+    # SAP Note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
     if [[ $(uname -m) == x86_64 ]]; then
         cur_val=$(sed 's%.*\[\(.*\)\].*%\1%' /sys/kernel/mm/transparent_hugepage/enabled)
         THP=$(chk_conf_val THP "$cur_val")
@@ -111,7 +111,6 @@ stop() {
 
     revert_preparation
     revert_page_cache_limit
-    revert_uuidd_socket
     #revert_shmmni
 
     # Restore kernel.shmmni, vm.dirty_bytes, vm.dirty_background_bytes, net.ipv4.tcp_slow_start_after_idle

--- a/profile/sap-netweaver/script.sh
+++ b/profile/sap-netweaver/script.sh
@@ -4,7 +4,7 @@
 # Optimise kernel parameters for running SAP HANA and HANA based products (such as Business One).
 # The calculations are based on:
 # - Parameters tuned by SAP installation wizard and configure_HANA.sh.
-# - Various SAP notes.
+# - Various SAP Notes.
 # Authors:
 #   Angela Briel <abriel@suse.com>
 #   Howard Guo <hguo@suse.com>
@@ -17,9 +17,9 @@ start() {
     log "--- Going to apply SAP tuning techniques"
     # Common tuning techniques apply to HANA and NetWeaver
     tune_preparation
-    # SAP note 1557506 - Linux paging improvements
+    # SAP Note 1557506 - Linux paging improvements
     tune_page_cache_limit
-    # SAP note 1984787 - Installation notes
+    # SAP Note 1984787 - Installation notes
     tune_uuidd_socket
 
     # Read value requirements from sysconfig
@@ -45,11 +45,11 @@ start() {
         fi
     done
 
-    # SAP Note 2534844, bsc#874778
+    # SAP Note 2534844
     save_value kernel.shmmni "$(sysctl -n kernel.shmmni)"
     chk_and_set_conf_val SHMMNI kernel.shmmni
 
-    # TID_7010287
+    # SAP Note 1984787
     save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
     save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
     chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
@@ -57,7 +57,7 @@ start() {
     save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
     chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
 
-    # SAP note
+    # SAP Note 2382421
     cur_val=$(sysctl -n net.ipv4.tcp_slow_start_after_idle)
     TCP_SLOW_START=$(chk_conf_val TCP_SLOW_START "$cur_val")
     if [ "$cur_val" != "$TCP_SLOW_START" ]; then
@@ -68,7 +68,7 @@ start() {
         log "Leaving net.ipv4.tcp_slow_start_after_idle unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - KSM and AutoNUMA both should be off
+    # SAP Note 2205917 - KSM and AutoNUMA both should be off
     cur_val=$(cat /sys/kernel/mm/ksm/run)
     KSM=$(chk_conf_val KSM "$cur_val")
     if [ "$cur_val" != "$KSM" ]; then
@@ -88,8 +88,8 @@ start() {
         log "Leaving numa_balancing unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - Transparent Hugepage should be never
-    # SAP note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
+    # SAP Note 2205917 - Transparent Hugepage should be never
+    # SAP Note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
     if [[ $(uname -m) == x86_64 ]]; then
         cur_val=$(sed 's%.*\[\(.*\)\].*%\1%' /sys/kernel/mm/transparent_hugepage/enabled)
         THP=$(chk_conf_val THP "$cur_val")
@@ -111,7 +111,6 @@ stop() {
 
     revert_preparation
     revert_page_cache_limit
-    revert_uuidd_socket
     #revert_shmmni
 
     # Restore kernel.shmmni, vm.dirty_bytes, vm.dirty_background_bytes, net.ipv4.tcp_slow_start_after_idle

--- a/sapconf.service
+++ b/sapconf.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=sapconf
 After=syslog.target systemd-sysctl.service network.target
-# SAP Note 1310037 (still valid)
+# SAP Note 1984787
 Wants=sysstat.service
 # Requested by https://bugzilla.suse.com/show_bug.cgi?id=983454 :
 # UUID should work properly (enabled) as soon as this package is installed.

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -49,7 +49,7 @@ SHMMAX=18446744073709551615
 # The next 4 values define the Semaphore limits
 # kernel.sem = SEMMSL SEMMNS SEMOPM SEMMNI
 #
-# SAP Note 1275776
+# SAP Note 1984787
 #
 
 # The lower tuning limit of the maximum number of semaphores per semaphore set.
@@ -98,7 +98,7 @@ LIMIT_6="@dba hard nofile 65536"
 #
 # vm.max_map_count should be set to MAX_INT (2147483647)
 #
-# SAP Note 1275776, 900929, HANA Administration Guide
+# SAP Note 1980196, 900929, HANA Administration Guide
 #
 MAX_MAP_COUNT=2147483647
 
@@ -108,9 +108,9 @@ MAX_MAP_COUNT=2147483647
 #
 # kernel.shmmni is set to the SHMMNI value from this file
 #
-# kernel.shmmni should be set to 32768 (see bsc#874778)
+# kernel.shmmni should be set to 32768
 #
-# SAP Note 2534844, bsc#874778, HANA Administration Guide
+# SAP Note 2534844, HANA Administration Guide
 #
 SHMMNI=32768
 
@@ -131,7 +131,7 @@ SHMMNI=32768
 #
 # vm.dirty_bytes should be set to 629145600 (see TID_7010287)
 #
-# TID_7010287
+# SAP Note 1984787, SAP Note 1557506
 #
 DIRTY_BYTES=629145600
 
@@ -149,7 +149,7 @@ DIRTY_BYTES=629145600
 #
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #
-# TID_7010287
+# SAP Note 1984787, SAP Note 1557506
 #
 DIRTY_BG_BYTES=314572800
 
@@ -162,7 +162,8 @@ DIRTY_BG_BYTES=314572800
 # This value is important for large ScaleOut HANA clusters and HANA2 in general.
 # So disable TCP slow start on idle connections
 # set net.ipv4.tcp_slow_start_after_idle=0
-# SAP Note
+#
+# SAP Note 2382421
 #
 TCP_SLOW_START=0
 
@@ -240,7 +241,7 @@ ENABLE_PAGECACHE_LIMIT="no"
 # SAP Note 1557506
 #
 # Please uncomment the following line and set your preferred value
-#PAGECACHE_LIMIT_MB=""
+#PAGECACHE_LIMIT_MB = ""
 
 # vm.pagecache_limit_ignore_dirty
 # Whether or not to ignore dirty memory when enforcing the pagecache limit.
@@ -254,7 +255,7 @@ ENABLE_PAGECACHE_LIMIT="no"
 # SAP Note 1557506
 #
 # Please uncomment the following line and set your preferred value
-#PAGECACHE_LIMIT_IGNORE_DIRTY=""
+#PAGECACHE_LIMIT_IGNORE_DIRTY = ""
 
 
 ###############################################################################
@@ -330,7 +331,7 @@ ENABLE_PAGECACHE_LIMIT="no"
 #
 # Value is commented out by default
 #
-# SAP Note
+# SAP Note 2205917
 #
 #min_perf_pct = 100
 
@@ -350,7 +351,7 @@ ENABLE_PAGECACHE_LIMIT="no"
 # When set, all block devices on the system will be switched to the chosen
 # scheduler.
 #
-# SAP Note
+# SAP Note 1984787
 #
 #elevator = noop
 
@@ -358,7 +359,7 @@ ENABLE_PAGECACHE_LIMIT="no"
 #
 # Requirements and settings during sapconf package installation:
 #
-# sysstat - see SAP Note 1310037
+# sysstat - see SAP Note 1984787
 # package requirement, service is enabled and started during post installation
 # script
 #
@@ -383,4 +384,5 @@ ENABLE_PAGECACHE_LIMIT="no"
 # UserTasksMax will be set to 'infinity'
 # A message will indicate if a reboot/restart is necessary.
 #
-#SAPCONF_END=""
+# SCCU1
+#SAPCONF_END = ""


### PR DESCRIPTION
… file of the sapconf package. (bsc#1096496)
allow admin to exclude VSZ_TMPFS settings from sysconfig file, so system value will be untouched. (bsc#1093844)
do NOT (never ever) disable uuidd.socket (bsc#1093843)

Additional information:
bsc#1096496
correct the SAP Note references in the man pages and in the sysconfig file of the sapconf package
The changes in the comment sections of the sysconfig file need to be done per script (sccu.sh - 'sapconf comment update') during the post script of the package installation because the normally used tools like 'fillup' do NOT change comment sections of sysconfig files.

bsc#1093844
remove hardcoded default value for VSZ_TMPFS_PERCENT. This allows an admin to exclude VSZ_TMPFS settings from the sysconfig file, so current system value will remain untouched.
This default value only got used in the previous version, if the variable VSZ_TMPFS_PERCENT was removed from the sapconf configuration file /etc/sysconfig/sapconf.
If the value of the variable was only changed (increase or decrease) in the sapconf configuration file everything works fine.

bsc#1093843
never ever stop or disable uuidd.socket in sapconf.
It is mandatory for every SAP application running.

consolidate all SAP ASE (Sybase) related configuration settings into the configuration file /etc/sysconfig/sapnote-1680803. On the analogy of bsc#1070508

additionally  fixed in the post script of the package installation (in OBS):

bsc#1093315
correct pattern search in /etc/sysconfig/sapnote-1557506 to get update of /etc/sysconfig/sapconf to work.
The problem only occurs, if /etc/sysconfig/sapnote-1557506 contains commented variable lines like '#PAGECACHE_LIMIT_MB=""' in addition to the uncommented line 'PAGECACHE_LIMIT_MB="500"' If only the uncommented lines exist, everything works correctly.
