### PR TITLE
changes for the next sapconf version 4.2.1

### DIFF
--- a/lib/sccu.sh
+++ b/lib/sccu.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1004
+
+# sapconf comment update script
+# sccu.sh is called by post script of sapconf package installation to 
+# update the comment sections in the /etc/sysconfig/sapconf file
+# which is impossible by using /bin/fillup
+
+SN=/etc/sysconfig/sapconf
+# change commented variables so that fillup will preserve the trailing comments
+sed -i 's/\(^#.*\)=""$/\1 = ""/' $SN
+
+# change comments as requested in bsc#1096496
+if ! (grep "^# SCCU1$" $SN >/dev/null 2>&1); then
+    sed -i '/^# SAP Note$/{N;d}' $SN
+    sed -i 's/SAP Note 1275776,/SAP Note 1980196,/' $SN
+    sed -i 's/SAP Note 1275776/SAP Note 1984787/' $SN
+    sed -i 's/SAP Note 1310037/SAP Note 1984787/' $SN
+    sed -i 's/ (see bsc#874778)//' $SN
+    sed -i 's/ bsc#874778,//' $SN
+    sed -i 's/^# TID_7010287$/# SAP Note 1984787, SAP Note 1557506/' $SN
+    if ! (grep "^# SAP Note 2382421$" $SN >/dev/null 2>&1); then
+        sed -i '/^# set net.ipv4.tcp_slow_start_after_idle=0/a\
+#\
+# SAP Note 2382421\
+#' $SN
+    fi
+    sed -i '/^# scheduler.$/a\
+#\
+# SAP Note 1984787' $SN
+    sed -i '/^#min_perf_pct = 100$/i\
+# SAP Note 2205917\
+#' $SN
+    sed -i '/^#SAPCONF_END/i\
+# SCCU1' $SN
+fi
+
+# additonal changed comments as requested in bsc#1096498
+if ! (grep "^# SCCU1-15$" $SN >/dev/null 2>&1); then
+    sed -i 's/, SAP Note 1557506$//' $SN
+    sed -i 's/2205917/2684254/' $SN
+    sed -i 's/1984787/2578899/' $SN
+    sed -i 's/may be sap-hana or sap-netweaver/is sapconf/' $SN
+    sed -i '/^#SAPCONF_END/i\
+# SCCU1-15' $SN
+fi

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "April 2018" "sapconf configuration file"
+.TH sapconf 5 "August 2018" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -69,30 +69,6 @@ Linux kernel setting, set in the common part (tune_preparation) of the scripting
 SAP Note 941735, HANA Administration Guide
 .RE
 .PP
-.TP 0
-.BI "Semaphore limits"
-The next 4 values define the Semaphore limits \fBkernel.sem\fP
-.br
-kernel.sem = SEMMSL SEMMNS SEMOPM SEMMNI
-.RS 4
-.TP 3
-.BI SEMMSL=32000
-The lower tuning limit of the maximum number of semaphores per semaphore set.
-.TP 3
-.BI SEMMNS=1024000000
-The lower tuning limit of the maximum total number of semaphores.
-.TP 3
-.BI SEMOPM=500
-The lower tuning limit of the maximum number of semaphore operations that can be performed per "semop" system call.
-.TP 3
-.BI SEMMNI=32000
-The lower tuning limit of maxium total number of semaphore sets.
-.PP
-Semaphore limits, set in the common part (tune_preparation) of the scripting
-.br
-SAP Note 1275776
-.RE
-.PP
 \fBLIMIT_1="@sapsys soft nofile 65536"\fP
 .br
 \fBLIMIT_2="@sapsys hard nofile 65536"\fP
@@ -128,7 +104,7 @@ MAX_MAP_COUNT set to MAX_INT (2147483647)
 .RS 4
 Memory Management setting in the common part (tune_preparation) of the scripting
 .br
-SAP Note 1275776, 900929, HANA Administration Guide
+SAP Note 1980196, 900929, HANA Administration Guide
 .RE
 .PP
 .TP 4
@@ -140,7 +116,7 @@ The value is the maximum number of shared memory identifies available in the sys
 .RS 4
 Linux kernel setting, set in the profile specific part of the scripting
 .br
-SAP Note 2534844, bsc#874778, HANA Administration Guide
+SAP Note 2534844, HANA Administration Guide
 .RE
 .PP
 .TP 4
@@ -158,7 +134,7 @@ Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any val
 .RS 4
 Memory Management setting in the profile specific part of the scripting
 .br
-TID_7010287
+SAP Note 2578899
 .RE
 .PP
 .TP 4
@@ -174,7 +150,7 @@ Note: when changing the tuned profile or switching off tuned, both values will b
 .RS 4
 Memory Management setting in the profile specific part of the scripting
 .br
-TID_7010287
+SAP Note 2578899
 .RE
 .PP
 .TP 4
@@ -186,7 +162,7 @@ This value is important for large ScaleOut HANA clusters and HANA2 in general. S
 .RS 4
 IO related setting \fBnet.ipv4.tcp_slow_start_after_idle\fP during the profile specific part of the scripting
 .br
-SAP Note 
+SAP Note 2382421
 .RE
 .PP
 .TP 4
@@ -196,7 +172,7 @@ Kernel Samepage Merging (KSM). KSM allows for an application to register with th
 .RS 4
 Set in \fB/sys/kernel/mm/ksm/run\fP during the profile specific part of the scripting
 .br
-SAP Note 2205917
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -208,7 +184,7 @@ Turn off autoNUMA balancing. 0 to disable, 1 to enable
 .RS 4
 Set in \fB/proc/sys/kernel/numa_balancing\fP during the profile specific part of the scripting
 .br
-SAP Note 2205917
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -220,7 +196,7 @@ Set to 'never' to disable or to 'always' to enable.
 .RS 4
 Set in \fB/sys/kernel/mm/transparent_hugepage/enabled\fP during the profile specific part of the scripting
 .br
-SAP Note 2131662, 2205917, 2031375
+SAP Note 2131662, 2684254, 2031375
 .RE
 .PP
 .TP 0
@@ -245,7 +221,7 @@ The value is commented out by default
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note 2205917
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -263,7 +239,7 @@ The value is commented out by default
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note 2205917
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -279,7 +255,7 @@ To switch off these dynamically changes the latency can be forced to a specific 
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note 2205917
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -297,7 +273,7 @@ The value is commented out by default
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note
+SAP Note 2684254
 .RE
 .PP
 .TP 4
@@ -313,7 +289,7 @@ When set, all block devices on the system will be switched to the chosen schedul
 .RS 4
 Set during start, stop or profile change of tuned.
 .br
-SAP Note
+SAP Note 2578899
 .RE
 .PP
 .SH DESCRIPTION OF PART 3
@@ -324,19 +300,19 @@ These values are profile independent. They describe requirements and settings du
 .BI sysstat
 Package requirement. The service is started after installation of the package.
 .br
-SAP Note 1310037
+SAP Note 2578899
 .PP
 .TP 4
 .BI uuidd.socket
 Package requirement. The service is enabled and started after installation of the package.
 .br
-SAP Note 1984787
+SAP Note 2578899
 .PP
 .TP 4
 .BI sapinit-systemd-compat
 Package requirementm, only needed for SLES12GA and SLES12SP1. This package adds the needed drop-in file to the systemd configuration and told the daemon to re-read its configuration.
 .br
-SAP Note 1984787
+SAP Note 2578899
 .PP
 .TP 4
 .BI USERTASKSMAX=infinity
@@ -349,7 +325,7 @@ A message will indicate if a reboot is necessary.
 .br
 There is no rollback.
 .br
-SAP Note 2205917, 1984787
+SAP Note 2684254, 2578899
 .PP
 .SH "FILES"
 .PP

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 8 "April 2018" "util-linux" "System Administration"
+.TH sapconf 8 "August 2018" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -66,7 +66,7 @@ See the man page \fBtuned-profiles-sapconf(7)\fR for details.
 To get a better base in the future for mixed HANA and ABAB workloads on one system, sapconf will use the same tuning values for HANA, Sybase/ASE, BOBJ and NetWeaver workloads. That means that the former profiles "sap\-netweaver", "sap\-hana", "sap\-ase" and "sap\-bobj" existing in SLE12 are consolidated in one basic sapconf profile.
 
 .SH "SAP NOTES"
-All settings are done according to SAP note number 900929, 941735, 1275776, 1310037, 1557506, 1771258, 1984787, 2031375, 2055470, 2131662, 2205917, 2534844 and TID_7010287
+All settings are done according to SAP note number 900929, 941735, 1771258, 1980196, 2578899, 2031375, 2055470, 2131662, 2684254, 2382421 and 2534844
 .br
 See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR or \fBsapconf(5)\fP for details.
 
@@ -74,11 +74,11 @@ See the comments in the central sapconf configuration file \fI/etc/sysconfig/sap
 The following package requirements exist for the sapconf package:
 .TP 4
 .BI "sysstat" 
-service is started after package installation (see SAP Note 1310037)
+service is started after package installation (see SAP Note 2578899)
 .PP
 .TP 4
 .BI "uuidd.socket"
-service is enabled and started after package installation (see SAP Note 1984787)
+service is enabled and started after package installation (see SAP Note 2578899)
 .PP
 This information is additionally commented in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR.
 .PP

--- a/man/tuned-profiles-sapconf.7
+++ b/man/tuned-profiles-sapconf.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH TUNED_PROFILES_SAPCONF "7" "April 2018" "Adaptive system tuning daemon" "tuned"
+.TH TUNED_PROFILES_SAPCONF "7" "August 2018" "Adaptive system tuning daemon" "tuned"
 .SH NAME
 tuned\-profiles\-sapconf - Tuning profile for SAP workloads.
 
@@ -22,8 +22,6 @@ tuned\-profiles\-sapconf - Tuning profile for SAP workloads.
 The tuning profile automatically optimises kernel parameters and system configuration for running SAP workloads like NetWeaver, Sybase/ASE, BOBJ and HANA and Business One softwares.
 
 The following parameters are calculated and tuned, according to various SAP notes and best practices:
-.IP \[bu]
-Semaphores: kernel.sem
 .IP \[bu]
 Shared memory: kernel.shmall, kernel.shmmax, kernel.shmmni
 .IP \[bu]
@@ -55,7 +53,7 @@ Note that the former profiles
 now are consolidated to one base sapconf profile to get a better base in the future for mixed HANA and ABAB workloads on one system.
 
 .SH "SAP NOTES"
-The tuned parameters are calculated according to SAP note number 900929, 941735, 1275776, 1310037, 1771258, 1984787, 2031375, 2055470, 2131662, 2205917, 2534844 and TID_7010287
+The tuned parameters are calculated according to SAP note number 900929, 941735, 1771258, 1980196, 2578899, 2031375, 2055470, 2131662, 2684254, 2382421 and 2534844
 .br See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR for details.
 
 .SH ACTIVATION

--- a/profile/sapconf/script.sh
+++ b/profile/sapconf/script.sh
@@ -4,7 +4,7 @@
 # Optimise kernel parameters for running SAP HANA and HANA based products (such as Business One).
 # The calculations are based on:
 # - Parameters tuned by SAP installation wizard and configure_HANA.sh.
-# - Various SAP notes.
+# - Various SAP Notes.
 # Authors:
 #   Angela Briel <abriel@suse.com>
 #   Howard Guo <hguo@suse.com>
@@ -17,14 +17,15 @@ start() {
     log "--- Going to apply SAP tuning techniques"
     # Common tuning techniques apply to HANA and NetWeaver
     tune_preparation
-    # SAP note 1984787 - Installation notes
+    # SAP Note 2578899 - Installation notes
     tune_uuidd_socket
 
     # Read value requirements from sysconfig
     # if value is not set in sysconfig file, log a message and keep the
     # current system value
     if [ -r /etc/sysconfig/sapconf ]; then
-        source /etc/sysconfig/sapconf
+        # remove blanks from the variable declaration to prevent errors
+        sed -i '/^[^#].*[[:blank:]][[:blank:]]*=[[:blank:]][[:blank:]]*.*/s%[[:blank:]]%%g' /etc/sysconfig/sapconf && source /etc/sysconfig/sapconf
     else
         log 'Failed to read /etc/sysconfig/sapconf'
         exit 1
@@ -43,11 +44,11 @@ start() {
         fi
     done
 
-    # SAP Note 2534844, bsc#874778
+    # SAP Note 2534844
     save_value kernel.shmmni "$(sysctl -n kernel.shmmni)"
     chk_and_set_conf_val SHMMNI kernel.shmmni
 
-    # TID_7010287
+    # SAP Note 2578899
     save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
     save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
     chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
@@ -55,7 +56,7 @@ start() {
     save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
     chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
 
-    # SAP note
+    # SAP Note 2382421
     cur_val=$(sysctl -n net.ipv4.tcp_slow_start_after_idle)
     TCP_SLOW_START=$(chk_conf_val TCP_SLOW_START "$cur_val")
     if [ "$cur_val" != "$TCP_SLOW_START" ]; then
@@ -66,7 +67,7 @@ start() {
         log "Leaving net.ipv4.tcp_slow_start_after_idle unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - KSM and AutoNUMA both should be off
+    # SAP Note 2684254 - KSM and AutoNUMA both should be off
     cur_val=$(cat /sys/kernel/mm/ksm/run)
     KSM=$(chk_conf_val KSM "$cur_val")
     if [ "$cur_val" != "$KSM" ]; then
@@ -86,8 +87,8 @@ start() {
         log "Leaving numa_balancing unchanged at $cur_val"
     fi
 
-    # SAP note 2205917 - Transparent Hugepage should be never
-    # SAP note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
+    # SAP Note 2684254 - Transparent Hugepage should be never
+    # SAP Note 2055470 - Ignore transparent huge pages and c-state information given in the first two notes above. These technologies are different on IBM Power Servers. (Version 68 from Oct 11, 2017)
     if [[ $(uname -m) == x86_64 ]]; then
         cur_val=$(sed 's%.*\[\(.*\)\].*%\1%' /sys/kernel/mm/transparent_hugepage/enabled)
         THP=$(chk_conf_val THP "$cur_val")
@@ -108,7 +109,6 @@ stop() {
     log "--- Going to revert SAP tuned parameters"
 
     revert_preparation
-    revert_uuidd_socket
     #revert_shmmni
 
     # Restore kernel.shmmni, vm.dirty_bytes, vm.dirty_background_bytes, net.ipv4.tcp_slow_start_after_idle

--- a/sapconf.service
+++ b/sapconf.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=sapconf
 After=syslog.target systemd-sysctl.service network.target
-# SAP Note 1310037 (still valid)
+# SAP Note 2578899
 Wants=sysstat.service
 # Requested by https://bugzilla.suse.com/show_bug.cgi?id=983454 :
 # UUID should work properly (enabled) as soon as this package is installed.

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -44,34 +44,6 @@ SHMALL=1152921504606846720
 #
 SHMMAX=18446744073709551615
 
-# kernel.sem
-# The next 4 values define the Semaphore limits
-# kernel.sem = SEMMSL SEMMNS SEMOPM SEMMNI
-#
-# SAP Note 1275776
-#
-
-# The lower tuning limit of the maximum number of semaphores per semaphore set.
-# Set to 32000
-#
-SEMMSL=32000
-
-# The lower tuning limit of the maximum total number of semaphores.
-# Set to 1024000000
-#
-SEMMNS=1024000000
-
-# The lower tuning limit of the maximum number of semaphore operations that
-# can be performed per "semop" system call.
-# Set to 500
-#
-SEMOPM=500
-
-# The lower tuning limit of maxium total number of semaphore sets.
-# Set to 32000
-#
-SEMMNI=32000
-
 # /etc/security/limits.conf
 ## Type:        regexp(^@(sapsys|sdba|dba)[[:space:]]+(-|hard|soft)[[:space:]]+(nofile)[[:space:]]+[[:digit:]]+)
 #
@@ -97,7 +69,7 @@ LIMIT_6="@dba hard nofile 65536"
 #
 # vm.max_map_count should be set to MAX_INT (2147483647)
 #
-# SAP Note 1275776, 900929, HANA Administration Guide
+# SAP Note 1980196, 900929, HANA Administration Guide
 #
 MAX_MAP_COUNT=2147483647
 
@@ -107,9 +79,9 @@ MAX_MAP_COUNT=2147483647
 #
 # kernel.shmmni is set to the SHMMNI value from this file
 #
-# kernel.shmmni should be set to 32768 (see bsc#874778)
+# kernel.shmmni should be set to 32768
 #
-# SAP Note 2534844, bsc#874778, HANA Administration Guide
+# SAP Note 2534844, HANA Administration Guide
 #
 SHMMNI=32768
 
@@ -130,7 +102,7 @@ SHMMNI=32768
 #
 # vm.dirty_bytes should be set to 629145600 (see TID_7010287)
 #
-# TID_7010287
+# SAP Note 2578899
 #
 DIRTY_BYTES=629145600
 
@@ -148,7 +120,7 @@ DIRTY_BYTES=629145600
 #
 # vm.dirty_background_bytes should be set to 314572800 (see TID_7010287)
 #
-# TID_7010287
+# SAP Note 2578899
 #
 DIRTY_BG_BYTES=314572800
 
@@ -161,7 +133,8 @@ DIRTY_BG_BYTES=314572800
 # This value is important for large ScaleOut HANA clusters and HANA2 in general.
 # So disable TCP slow start on idle connections
 # set net.ipv4.tcp_slow_start_after_idle=0
-# SAP Note
+#
+# SAP Note 2382421
 #
 TCP_SLOW_START=0
 
@@ -176,7 +149,7 @@ TCP_SLOW_START=0
 #
 # ksm set to 0
 #
-# SAP Note 2205917
+# SAP Note 2684254
 #
 KSM=0
 
@@ -202,7 +175,7 @@ KSM=0
 # 0 to disable, 1 to enable
 # numa_balancing set to 0
 #
-# SAP Note 2205917
+# SAP Note 2684254
 #
 NUMA_BALANCING=0
 
@@ -213,7 +186,7 @@ NUMA_BALANCING=0
 # Disable transparent hugepages
 # set to 'never'
 #
-# SAP Note 2131662, 2205917, 2031375
+# SAP Note 2131662, 2684254, 2031375
 #
 THP=never
 
@@ -237,7 +210,7 @@ THP=never
 #
 # Value is commented out by default
 #
-# SAP Note 2205917
+# SAP Note 2684254
 #
 #energy_perf_bias = performance
 
@@ -252,7 +225,7 @@ THP=never
 #
 # Value is commented out by default
 #
-# SAP Note 2205917
+# SAP Note 2684254
 #
 #governor = performance
 
@@ -273,7 +246,7 @@ THP=never
 #
 # Value is set to 70
 #
-# SAP Note 2205917
+# SAP Note 2684254
 #
 #force_latency = 70
 
@@ -291,7 +264,7 @@ THP=never
 #
 # Value is commented out by default
 #
-# SAP Note
+# SAP Note 2684254
 #
 #min_perf_pct = 100
 
@@ -311,7 +284,7 @@ THP=never
 # When set, all block devices on the system will be switched to the chosen
 # scheduler.
 #
-# SAP Note
+# SAP Note 2578899
 #
 #elevator = noop
 
@@ -319,19 +292,19 @@ THP=never
 #
 # Requirements and settings during sapconf package installation:
 #
-# sysstat - see SAP Note 1310037
+# sysstat - see SAP Note 2578899
 # package requirement, service is enabled and started during post installation
 # script
 #
-# uuidd - see SAP Note 1984787
+# uuidd - see SAP Note 2578899
 # package requirement, service is enabled and started during post installation
 # script
 #
-# sapinit-systemd-compat - see SAP Note 1984787
+# sapinit-systemd-compat - see SAP Note 2578899
 # package requirement, only needed for SLES12GA and SLES12SP1
 #
 # /etc/systemd/logind.conf.d/sap.conf UserTasksMax setting
-# see SAP Note 2205917 and 1984787
+# see SAP Note 2684254 and 2578899
 # This file configures a parameter of the systemd login manager
 # It sets the maximum number of OS tasks each user may run concurrently
 # The behaviour of the systemd login manager was changed starting SLES12SP2
@@ -344,4 +317,6 @@ THP=never
 # UserTasksMax will be set to 'infinity'
 # A message will indicate if a reboot/restart is necessary.
 #
-#SAPCONF_END=""
+# SCCU1
+# SCCU1-15
+#SAPCONF_END = ""


### PR DESCRIPTION
bsc#1099101
Do not change the system settings for kernel.sem. So remove the variables SEM* from sapconf.

bsc#1096498
correct the SAP Note references in the man pages and in the sysconfig file of the sapconf package
The changes in the comment sections of the sysconfig file need to be done per script (sccu.sh - 'sapconf comment update') during the post script of the package installation because the normally used tools like 'fillup' do NOT change comment sections of sysconfig files.

bsc#1093844
remove hardcoded default value for VSZ_TMPFS_PERCENT. This allows an admin to exclude VSZ_TMPFS settings from the sysconfig file, so current system value will remain untouched.
This value only got used in the previous version, if the variable VSZ_TMPFS_PERCENT was removed from the sapconf configuration file /etc/sysconfig/sapconf.
If the value of the variable was only changed (increase or decrease) in the sapconf configuration file everything works fine.

bsc#1093843
never ever stop or disable uuidd.socket in sapconf.
It is mandatory for every SAP application running.

remove blanks from the variable declarations in the sysconfig files to prevent errors durig sourcing of the file