### PR TITLE
fixes for bsc#1139176 and bsc#1124453

### DIFF
--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2015-2018 SUSE LLC
+.\" * Copyright (c) 2015-2020 SUSE LLC
 .\" * Authors: Howard Guo
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 8 "August 2018" "util-linux" "System Administration"
+.TH sapconf 7 "February 2020" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -55,6 +55,14 @@ systemctl enabled sapconf.service
 Start
 .br
 systemctl start sapconf.service
+
+If the start of the sapconf.service failed, use the command '\fBsystemctl status sapconf -l\fR' to get detailed information about the failure.
+
+If you see the error message:
+.br
+\fBnon-sapconf tuned profile configured. Skipping activation. See man sapconf for details.\fR
+
+please check the active tuned profile by '\fBtuned-adm active\fR' and change it to the pre\-defined sapconf profile by '\fBtuned-adm profile sapconf\fR' and then start sapconf.service again.
 
 .SH PROFILES
 At the moment we're providing one pre\-defined profile:
@@ -104,7 +112,7 @@ Please stop the sysstat service manually, if it is not needed any longer.
 The central configuration file of sapconf is not removed during package removal.
 .PP
 .TP 4
-.BI /etc/tuned/sap\*
+.BI /etc/tuned/sap*
 Private copies of tuned profiles in /etc/tuned are not removed during package removal.
 .PP
 .TP 4

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -21,7 +21,7 @@ sapconf \- Kernel and system configuration for SAP products
 .SH DESCRIPTION
 sapconf and its profile "sapconf" work on top of the tune daemon (\fBtuned(8)\fP).
 .PP
-The profiles are stored in subdirectories below \fI/usr/lib/tuned\fP. If you need to customize the profiles, you can copy them to \fI/etc/tuned\fP and modify them as you need. If only copying the \fItuned.conf\fP file, please do not forget to adjust the script path in the \fB[script]\fP section to \fI/usr/lib/tuned/<profile>/script.sh\fP. Or copy the script.sh as well.
+The profiles are stored in subdirectories below \fI/usr/lib/tuned\fP. If you need to customize the profiles, you can copy them to \fI/etc/tuned\fP and modify them as you need. It's sufficient to copy the \fItuned.conf\fP file, so you can benefit from package updates of the \fIscript.sh\fP in \fI/usr/lib/tuned\fP.
 .PP
 When loading profiles the files in \fI/etc/tuned\fP takes precedence. In such case you will not lose your customized profiles between tuned or sapconf updates. But be in mind, to get the new behaviour the package update is carrying along, remove the profile copy from \fI/etc/tuned\fP or copy the new profile from \fI/usr/lib/tuned/<profile>\fP to \fI/etc/tuned/<profile>\fP or compare the files in \fI/etc/tuned/<profile>\fP with the files in \fI/usr/lib/tuned/<profile>\fP manually and adjust the content, if needed.
 .PP

--- a/profile/sapconf/tuned.conf
+++ b/profile/sapconf/tuned.conf
@@ -18,4 +18,4 @@ force_latency = 70
 elevator = noop
 
 [script]
-script = script.sh
+script = /usr/lib/tuned/sapconf/script.sh

--- a/sapconf.service
+++ b/sapconf.service
@@ -11,7 +11,7 @@ Requires=uuidd.socket
 Type=oneshot
 RemainAfterExit=true
 ExecStartPre=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) == "" ]]; then tuned-adm profile sapconf &> /dev/null; fi'
-ExecStart=/usr/bin/systemctl start tuned.service
+ExecStart=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) != sapconf ]]; then echo "non-sapconf tuned profile configured. Skipping activation. See man sapconf for details."; exit 1; else /usr/bin/systemctl start tuned.service; fi'
 ExecReload=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) == sapconf ]]; then /usr/bin/systemctl restart tuned.service; fi'
 ExecStop=/bin/sh -c 'if [[ $(cat /etc/tuned/active_profile) == sapconf ]]; then /usr/bin/systemctl stop tuned.service >/dev/null 2>&1;  > /etc/tuned/active_profile; fi'
 


### PR DESCRIPTION
- if sapconf detects an improper tuned profile during start it will write an information to the log file and the start of the sapconf service will fail to guide the administrator to the problem.
  (bsc#1139176)
- use absolute path to script.sh in tuned.conf file
  (bsc#1124453)