### PR TITLE
fixes for bsc#1139176 and bsc#1124453 in SLE12

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -4,7 +4,7 @@
 #
 # /usr/sbin/sapconf
 #
-# Copyright (c) 2015-2017 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -50,6 +50,10 @@ case "$1" in
       profile=$(cat /var/lib/sapconf/last_profile 2> /dev/null)
       profile=${profile:-sap-netweaver}
       tuned-adm profile "$profile" &> /dev/null
+    fi
+    if [[ $(cat /etc/tuned/active_profile) != sap-* ]]; then
+      echo 'non-sapconf tuned profile configured. Skipping activation. See man sapconf for details.'
+      exit 1
     fi
     if ! systemctl status tuned &> /dev/null; then
       systemctl start tuned

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -22,7 +22,7 @@ sapconf \- Kernel and system configuration for SAP products
 For compatibility reasons the command sapconf(8) exists.
 .\" *But sapconf(8) is deprecated in favour of tune daemon (tuned) and its profiles "sap-netweaver", "sap-hana", "sap-ase", "sap-bobj" bnc#1098352.
 .PP
-The profiles are stored in subdirectories below \fI/usr/lib/tuned\fP. If you need to customize the profiles, you can copy them to \fI/etc/tuned\fP and modify them as you need. If only copying the \fItuned.conf\fP file, please do not forget to adjust the script path in the \fB[script]\fP section to \fI/usr/lib/tuned/<profile>/script.sh\fP. Or copy the script.sh as well.
+The profiles are stored in subdirectories below \fI/usr/lib/tuned\fP. If you need to customize the profiles, you can copy them to \fI/etc/tuned\fP and modify them as you need. It's sufficient to copy the \fItuned.conf\fP file, so you can benefit from package updates of the \fIscript.sh\fP in \fI/usr/lib/tuned\fP.
 .PP
 When loading profiles the files in \fI/etc/tuned\fP takes precedence. In such case you will not lose your customized profiles between tuned or sapconf updates. But be in mind, to get the new behaviour the package update is carrying along, remove the profile copy from \fI/etc/tuned\fP or copy the new profile from \fI/usr/lib/tuned/<profile>\fP to \fI/etc/tuned/<profile>\fP or compare the files in \fI/etc/tuned/<profile>\fP with the files in \fI/usr/lib/tuned/<profile>\fP manually and adjust the content, if needed.
 .PP

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2015-2018 SUSE LLC
+.\" * Copyright (c) 2015-2020 SUSE LLC
 .\" * Authors: Howard Guo
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 8 "June 2018" "util-linux" "System Administration"
+.TH sapconf 8 "February 2020" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -56,6 +56,14 @@ systemctl enabled sapconf.service
 Start
 .br
 systemctl start sapconf.service
+
+If the start of the sapconf.service failed, use the command '\fBsystemctl status sapconf -l\fR' to get detailed information about the failure.
+
+If you see the error message:
+.br
+\fBnon-sapconf tuned profile configured. Skipping activation. See man sapconf for details.\fR
+
+please check the active tuned profile by '\fBtuned-adm active\fR' and change it to one of the pre\-defined profiles listed below by '\fBtuned-adm profile <profile>\fR' and then start sapconf.service again.
 
 .SH PROFILES
 At the moment we're providing the following pre\-defined profiles:

--- a/man/sapconf.8
+++ b/man/sapconf.8
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2015-2017 SUSE LLC
+.\" * Copyright (c) 2015-2020 SUSE LLC
 .\" * Authors: Howard Guo
 .\" *	       Zsolt KALMAR
 .\" *
@@ -15,7 +15,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 8 "April 2018" "util-linux" "System Administration"
+.TH sapconf 8 "February 2020" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -30,6 +30,12 @@ sapconf activates SAP NetWeaver, SAP ASE/Sybase, SAP Business OBJects (BOBJ) or 
 
 .IP \[bu]
 start,restart,try-restart - If the tune daemon does not have any profile active and there is no information about the last used sapconf profile available in \fI/var/lib/sapconf/last_profile\fR, activate SAP NetWeaver tuning profile. Otherwise leave the profile choice alone and activate tune daemon.
+
+If the start failed and you get the error message:
+.br
+\fBnon-sapconf tuned profile configured. Skipping activation. See man sapconf for details.\fR
+
+please check the active tuned profile by '\fBtuned-adm active\fR' and change it to one of the pre\-defined sapconf profiles by '\fBtuned-adm profile <profile>\fR' and then start sapconf again.
 
 .IP \[bu]
 reload - If the current tuned profile is a sapconf profile, restart the tuned service.

--- a/profile/sap-ase/tuned.conf
+++ b/profile/sap-ase/tuned.conf
@@ -35,4 +35,4 @@ net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 65536 16777216
 
 [script]
-script = script.sh
+script = /usr/lib/tuned/sapconf/script.sh

--- a/profile/sap-bobj/tuned.conf
+++ b/profile/sap-bobj/tuned.conf
@@ -26,4 +26,4 @@ readahead = 4096
 kernel.sem = 250 32000 32 1024
 
 [script]
-script = script.sh
+script = /usr/lib/tuned/sapconf/script.sh

--- a/profile/sap-hana/tuned.conf
+++ b/profile/sap-hana/tuned.conf
@@ -17,4 +17,4 @@ force_latency = 70
 elevator = noop
 
 [script]
-script = script.sh
+script = /usr/lib/tuned/sapconf/script.sh

--- a/profile/sap-netweaver/tuned.conf
+++ b/profile/sap-netweaver/tuned.conf
@@ -17,4 +17,4 @@ force_latency = 70
 elevator = noop
 
 [script]
-script = script.sh
+script = /usr/lib/tuned/sapconf/script.sh


### PR DESCRIPTION
- if sapconf detects an improper tuned profile during start it will write an information to the log file and the start of the sapconf service will fail to guide the administrator to the problem.
  (bsc#1139176)
- use absolute path to script.sh in tuned.conf file
  (bsc#1124453)