### PR TITLE
file /etc/systemd/logind.conf.d/sap.conf will be removed during the p…

### DIFF
--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2017-2018 SUSE LLC
+.\" * Copyright (c) 2017-2020 SUSE LLC
 .\" * Authors: Angela Briel
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "August 2018" "sapconf configuration file"
+.TH sapconf 5 "March 2020" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -313,19 +313,6 @@ SAP Note 2578899
 Package requirementm, only needed for SLES12GA and SLES12SP1. This package adds the needed drop-in file to the systemd configuration and told the daemon to re-read its configuration.
 .br
 SAP Note 2578899
-.PP
-.TP 4
-.BI USERTASKSMAX=infinity
-The file \fB/etc/systemd/logind.conf.d/sap.conf\fP configures a parameter of the systemd login manager. It sets the maximum number of OS tasks each user may run concurrently. The behaviour of the systemd login manager was changed starting SLES12SP2 to prevent fork bomb attacks. So no need to set in SLES12SP1.
-.br
-The file will be created during package installation, if it does not already exists.
-.br
-Note: A reboot is needed after the first setup to get the change take effect.
-A message will indicate if a reboot is necessary.
-.br
-There is no rollback.
-.br
-SAP Note 2684254, 2578899
 .PP
 .SH "FILES"
 .PP

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 7 "February 2020" "util-linux" "System Administration"
+.TH sapconf 7 "March 2020" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -93,12 +93,6 @@ This information is additionally commented in the central sapconf configuration 
 Note: These settings are profile independent. They will be applied during the post stage of the sapconf package installation.
 .PP
 Note: If the package sapconf is removed from the system, the following settings will still remain:
-.TP 4
-.BI "UserTasksMax setting in /etc/systemd/logind.conf.d/sap.conf"
-Please remove the file manually, if it is not needed any longer.
-.br
-Note: A reboot is needed after the removal of the file to get the change take effect.
-.PP
 .TP 4
 .BI "Maximum number of open file descriptors in /etc/security/limits.conf"
 Please remove the entries manually, if they are not needed any longer.

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -303,19 +303,6 @@ THP=never
 # sapinit-systemd-compat - see SAP Note 2578899
 # package requirement, only needed for SLES12GA and SLES12SP1
 #
-# /etc/systemd/logind.conf.d/sap.conf UserTasksMax setting
-# see SAP Note 2684254 and 2578899
-# This file configures a parameter of the systemd login manager
-# It sets the maximum number of OS tasks each user may run concurrently
-# The behaviour of the systemd login manager was changed starting SLES12SP2
-# to prevent fork bomb attacks.
-# No need to set in SLES12SP1.
-#
-# Note: A reboot is needed after the first setup or after setting a new value
-# to get the change take effect.
-# The file will be created during the package installation. The value for
-# UserTasksMax will be set to 'infinity'
-# A message will indicate if a reboot/restart is necessary.
 #
 # SCCU1
 # SCCU1-15


### PR DESCRIPTION
…ackage update. It is not needed any longer as the limits for TasksMax and UserTasksMax are removed from systemd/logind (bsc#1148163, jsc#SLE-10123)

The removal is done in the postinstall of the package. But we need to adapt the documentation too.