### PR TITLE
check the values of the vm.dirty_* settings to be in a valid range be…

### DIFF
--- a/logrotate/sapconf
+++ b/logrotate/sapconf
@@ -1,0 +1,9 @@
+/var/log/sapconf.log {
+    compress
+    copytruncate
+    dateext
+    rotate 99
+    size +4096k
+    notifempty
+    missingok
+}


### PR DESCRIPTION
…fore activating or restoring these system values. (bsc#1168067)

add a logrotate drop-in file for sapconf to control the size of the /var/log/sapconf.log logfile (bsc#1166925)