### PR TITLE
check the values of the vm.dirty_* settings to be in a valid range be…

### DIFF
--- a/logrotate/sapconf
+++ b/logrotate/sapconf
@@ -1,0 +1,9 @@
+/var/log/sapconf.log {
+    compress
+    copytruncate
+    dateext
+    rotate 99
+    size +4096k
+    notifempty
+    missingok
+}

--- a/profile/sap-hana/script.sh
+++ b/profile/sap-hana/script.sh
@@ -26,7 +26,7 @@ start() {
     # if value is not set in sysconfig file, log a message and keep the
     # current system value
     if [ -r /etc/sysconfig/sapconf ]; then
-	source_sysconfig /etc/sysconfig/sapconf
+        source_sysconfig /etc/sysconfig/sapconf
     else
         log 'Failed to read /etc/sysconfig/sapconf'
         exit 1
@@ -50,12 +50,25 @@ start() {
     chk_and_set_conf_val SHMMNI kernel.shmmni
 
     # SAP Note 1984787
-    save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
-    save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
-    chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
-    save_value vm.dirty_background_bytes "$(sysctl -n vm.dirty_background_bytes)"
-    save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
-    chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
+    ps=$(getconf PAGESIZE)
+    [ ! "$ps" ] && ps=4096 # fallback and set a default
+    min_val=$(math "$ps * 2")
+    if [ "$DIRTY_BYTES" != "" ] && [ "$DIRTY_BYTES" -lt "$min_val" ]; then
+        log "ATTENTION: wrong value set in sysconfig file for 'DIRTY_BYTES'. It's '$DIRTY_BYTES', but need to be at least '$min_val'"
+        log "Leaving vm.dirty_bytes unchanged"
+    else
+        save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
+        save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
+        chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
+    fi
+    if [ "$DIRTY_BG_BYTES" != "" ] && [ "$DIRTY_BG_BYTES" -eq 0 ]; then
+        log "ATTENTION: wrong value set in sysconfig file for 'DIRTY_BG_BYTES'. It's set to '0', but needs to be >0"
+        log "Leaving vm.dirty_background_bytes unchanged"
+    else
+        save_value vm.dirty_background_bytes "$(sysctl -n vm.dirty_background_bytes)"
+        save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
+        chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
+    fi
 
     # SAP Note 2382421
     cur_val=$(sysctl -n net.ipv4.tcp_slow_start_after_idle)
@@ -118,8 +131,24 @@ stop() {
     # to revert vm.dirty_background_ratio (reset during set of vm.dirty_background_bytes)
     # first revert vm.dirty_background_bytes, then vm.dirty_background_ratio
     for rest_value in kernel.shmmni vm.dirty_ratio vm.dirty_bytes vm.dirty_background_bytes vm.dirty_background_ratio net.ipv4.tcp_slow_start_after_idle; do
-	TVAL=$(restore_value $rest_value)
-	[ "$TVAL" ] && log "Restoring $rest_value=$TVAL" && sysctl -w "$rest_value=$TVAL"
+        TVAL=$(restore_value $rest_value)
+        [ ! "$TVAL" ] && continue
+        case "$rest_value" in
+        vm.dirty_ratio|vm.dirty_background_bytes|vm.dirty_background_ratio)
+            if [ "$TVAL" -eq 0 ]; then
+                TVAL=""
+            fi
+        ;;
+        vm.dirty_bytes)
+            ps=$(getconf PAGESIZE)
+            [ ! "$ps" ] && ps=4096 # fallback and set a default
+            min_val=$(math "$ps * 2")
+            if [ "$TVAL" -eq 0 ] || [ "$TVAL" -lt "$min_val" ]; then
+                TVAL=""
+            fi
+        ;;
+        esac
+        [ "$TVAL" ] && log "Restoring $rest_value=$TVAL" && sysctl -w "$rest_value=$TVAL"
     done
 
     # Restore THP, KSM and AutoNUMA settings

--- a/profile/sap-netweaver/script.sh
+++ b/profile/sap-netweaver/script.sh
@@ -26,7 +26,7 @@ start() {
     # if value is not set in sysconfig file, log a message and keep the
     # current system value
     if [ -r /etc/sysconfig/sapconf ]; then
-	source_sysconfig /etc/sysconfig/sapconf
+        source_sysconfig /etc/sysconfig/sapconf
     else
         log 'Failed to read /etc/sysconfig/sapconf'
         exit 1
@@ -50,12 +50,25 @@ start() {
     chk_and_set_conf_val SHMMNI kernel.shmmni
 
     # SAP Note 1984787
-    save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
-    save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
-    chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
-    save_value vm.dirty_background_bytes "$(sysctl -n vm.dirty_background_bytes)"
-    save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
-    chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
+    ps=$(getconf PAGESIZE)
+    [ ! "$ps" ] && ps=4096 # fallback and set a default
+    min_val=$(math "$ps * 2")
+    if [ "$DIRTY_BYTES" != "" ] && [ "$DIRTY_BYTES" -lt "$min_val" ]; then
+        log "ATTENTION: wrong value set in sysconfig file for 'DIRTY_BYTES'. It's '$DIRTY_BYTES', but need to be at least '$min_val'"
+        log "Leaving vm.dirty_bytes unchanged"
+    else
+        save_value vm.dirty_bytes "$(sysctl -n vm.dirty_bytes)"
+        save_value vm.dirty_ratio "$(sysctl -n vm.dirty_ratio)" # value needed for revert of vm.dirty_bytes
+        chk_and_set_conf_val DIRTY_BYTES vm.dirty_bytes
+    fi
+    if [ "$DIRTY_BG_BYTES" != "" ] && [ "$DIRTY_BG_BYTES" -eq 0 ]; then
+        log "ATTENTION: wrong value set in sysconfig file for 'DIRTY_BG_BYTES'. It's set to '0', but needs to be >0"
+        log "Leaving vm.dirty_background_bytes unchanged"
+    else
+        save_value vm.dirty_background_bytes "$(sysctl -n vm.dirty_background_bytes)"
+        save_value vm.dirty_background_ratio "$(sysctl -n vm.dirty_background_ratio)" # value needed for revert of vm.dirty_background_bytes
+        chk_and_set_conf_val DIRTY_BG_BYTES vm.dirty_background_bytes
+    fi
 
     # SAP Note 2382421
     cur_val=$(sysctl -n net.ipv4.tcp_slow_start_after_idle)
@@ -118,8 +131,24 @@ stop() {
     # to revert vm.dirty_background_ratio (reset during set of vm.dirty_background_bytes)
     # first revert vm.dirty_background_bytes, then vm.dirty_background_ratio
     for rest_value in kernel.shmmni vm.dirty_ratio vm.dirty_bytes vm.dirty_background_bytes vm.dirty_background_ratio net.ipv4.tcp_slow_start_after_idle; do
-	TVAL=$(restore_value $rest_value)
-	[ "$TVAL" ] && log "Restoring $rest_value=$TVAL" && sysctl -w "$rest_value=$TVAL"
+        TVAL=$(restore_value $rest_value)
+        [ ! "$TVAL" ] && continue
+        case "$rest_value" in
+        vm.dirty_ratio|vm.dirty_background_bytes|vm.dirty_background_ratio)
+            if [ "$TVAL" -eq 0 ]; then
+                TVAL=""
+            fi
+        ;;
+        vm.dirty_bytes)
+            ps=$(getconf PAGESIZE)
+            [ ! "$ps" ] && ps=4096 # fallback and set a default
+            min_val=$(math "$ps * 2")
+            if [ "$TVAL" -eq 0 ] || [ "$TVAL" -lt "$min_val" ]; then
+                TVAL=""
+            fi
+        ;;
+        esac
+        [ "$TVAL" ] && log "Restoring $rest_value=$TVAL" && sysctl -w "$rest_value=$TVAL"
     done
 
     # Restore THP, KSM and AutoNUMA settings


### PR DESCRIPTION
…fore activating or restoring these system values. (bsc#1168067)

add a logrotate drop-in file for sapconf to control the size of the /var/log/sapconf.log logfile (bsc#1166925)