### PR TITLE
Fix problems found during rewrite of the existing sapconf qa tests

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -158,6 +158,10 @@ case "$1" in
     # This is a new option, an extension to the traditional sapconf.
     # It activates NetWeaver tuning.
     log "--- Going to apply netweaver tuning techniques"
+    if [[ $profile == sapconf-netweaver ]]; then
+      log "profile '$profile' already active, no second start supported"
+      exit 0
+    fi
     if [[ $profile != "" && $profile != sapconf-netweaver ]]; then
       log "profile '$profile' currently active, please revert these settings first by using 'sapconf stop'"
       exit 1
@@ -171,6 +175,10 @@ case "$1" in
     # This is a new option, an extension to the traditional sapconf.
     # It activates HANA tuning.
     log "--- Going to apply hana tuning techniques"
+    if [[ $profile == sapconf-hana ]]; then
+      log "profile '$profile' already active, no second start supported"
+      exit 0
+    fi
     if [[ $profile != "" && $profile != sapconf-hana ]]; then
       log "profile '$profile' currently active, please revert these settings first by using 'sapconf stop'"
       exit 1
@@ -184,6 +192,10 @@ case "$1" in
     # This is a new option, an extension to the traditional sapconf.
     # It activates SAP ASE tuning.
     log "--- Going to apply ase tuning techniques"
+    if [[ $profile == sapconf-ase ]]; then
+      log "profile '$profile' already active, no second start supported"
+      exit 0
+    fi
     if [[ $profile != "" && $profile != sapconf-ase ]]; then
       log "profile '$profile' currently active, please revert these settings first by using 'sapconf stop'"
       exit 1
@@ -197,6 +209,10 @@ case "$1" in
     # This is a new option, an extension to the traditional sapconf.
     # It activates SAP Business OBJects tuning.
     log "--- Going to apply bobj tuning techniques"
+    if [[ $profile == sapconf-bobj ]]; then
+      log "profile '$profile' already active, no second start supported"
+      exit 0
+    fi
     if [[ $profile != "" && $profile != sapconf-bobj ]]; then
       log "profile '$profile' currently active, please revert these settings first by using 'sapconf stop'"
       exit 1

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -212,12 +212,16 @@ revert_page_cache_limit() {
 
 # tune_uuidd_socket unconditionally enables and starts uuidd.socket as recommended in "1984787 - Installation notes".
 tune_uuidd_socket() {
+    # paranoia: should not happen, because uuidd.socket should be enabled
+    # by vendor preset and sapconf.service should start uuidd.socket.
     if ! systemctl is-active uuidd.socket; then
-        # paranoia: should not happen, because uuidd.socket should be enabled
-        # by vendor preset and sapconf.service should start uuidd.socket.
-        log "--- Going to enable and start uuidd.socket"
+        log "--- Going to start uuidd.socket"
         systemctl enable uuidd.socket
         systemctl start uuidd.socket
+    fi
+    if ! systemctl is-enabled uuidd.socket; then
+        log "--- Going to enable uuidd.socket"
+        systemctl enable uuidd.socket
     fi
 }
 

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "April 2020" "sapconf configuration file"
+.TH sapconf 5 "May 2020" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -149,7 +149,7 @@ Contains the amount of dirty memory at which a process generating disk writes wi
 .br
 Note: \fBvm.dirty_bytes\fP is the counterpart of \fBvm.dirty_ratio\fP. Only one of them may be specified at a time. When one sysctl is written it is immediately taken into account to evaluate the dirty memory limits and the other appears as 0 when read.
 .br
-Note: when changing the tuned profile or switching off tuned, both values will be set back to their previous settings.
+Note: when changing the sapconf profile or stopping sapconf service, both values will be set back to their previous settings.
 .br
 Note: the minimum value allowed for dirty_bytes is two pages (in bytes); any value lower than this limit will be ignored and the old configuration will be retained.
 .br
@@ -167,7 +167,7 @@ Contains the amount of dirty memory at which the background kernel flusher threa
 .br
 Note: \fBvm.dirty_background_bytes\fP is the counterpart of \fBvm.dirty_background_ratio\fP.  Only one of them may be specified at a time. When one sysctl is written it is immediately taken into account to evaluate the dirty memory limits and the other appears as 0 when read.
 .br
-Note: when changing the tuned profile or switching off tuned, both values will be set back to their previous settings.
+Note: when changing the sapconf profile or stopping sapconf service, both values will be set back to their previous settings.
 .br
 \fBvm.dirty_background_bytes\fP is set to the DIRTY_BG_BYTES value from this file
 .PP
@@ -264,11 +264,6 @@ This will set \fBvm.pagecache_limit_ignore_dirty\fP during the common part (tune
 .br
 SAP Note 1557506
 .RE
-.PP
-.SH DESCRIPTION OF PART 2
-The parameters of the second part of the configuration file are not changeable in /etc/sysconfig/sapconf. They are part of this file for documentation purpose only.
-.PP
-These values are set in the configuration file \fB/usr/lib/tuned/<profile>/tuned.conf\fP, where <profile> may be sap-hana or sap-netweaver. See sapconf(7) for details how to change values from these configuration files.
 .PP
 .TP 4
 .BI PERF_BIAS=

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 7 "April 2020" "util-linux" "System Administration"
+.TH sapconf 7 "May 2020" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -44,6 +44,16 @@ To activate a sapconf tuning profile, run as root:
 /usr/sbin/sapconf <profile>
 .br
 valid values for <profile> are \fInetweaver\fP,\fIhana\fP, \fIb1\fP, \fIase\fP, \fIsybase\fP, \fIbobj\fP. The sapconf internal representation of these values will be stored in \fI/var/lib/sapconf/act_profile\fP.
+.PP
+For the sapconf internal representation (value stored in \fI/var/lib/sapconf/act_profile\fP or \fI/var/lib/sapconf/last_profile\fP) the following mapping will be used:
+.br
+netweaver - sapconf-netweaver
+.br
+hana, b1 - sapconf-hana
+.br
+ase, sybase - sapconf-ase
+.br
+bobj - sapconf-bobj
 .PP
 Make sure that the sapconf service is enabled and running.
 .br


### PR DESCRIPTION
change uuidd handling
add workaround for virtio block devices in scheduler settings
add missing profile check to /usr/sbin/sapconf to prevent a second start of an already running sapconf
fix man pages