### PR TITLE
Fix problems found during rewrite of the existing sapconf qa tests

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -136,12 +136,15 @@ revert_preparation() {
 
 # tune_uuidd_socket unconditionally enables and starts uuidd.socket as recommended in "2578899 - Installation notes".
 tune_uuidd_socket() {
+    # paranoia: should not happen, because uuidd.socket should be enabled
+    # by vendor preset and sapconf.service should start uuidd.socket.
     if ! systemctl is-active uuidd.socket; then
-        # paranoia: should not happen, because uuidd.socket should be enabled
-        # by vendor preset and sapconf.service should start uuidd.socket.
-        log "--- Going to enable and start uuidd.socket"
-        systemctl enable uuidd.socket
+        log "--- Going to start uuidd.socket"
         systemctl start uuidd.socket
+    fi
+    if ! systemctl is-enabled uuidd.socket; then
+        log "--- Going to enable uuidd.socket"
+        systemctl enable uuidd.socket
     fi
 }
 

--- a/lib/sapconf
+++ b/lib/sapconf
@@ -33,7 +33,7 @@ start() {
     # prevent a second start (apply of values) as this will override the
     # saved old values of the parameters and reverting back to the
     # original state will be impossible
-    [ -f /var/run/sapconf/active ] && log "sapconf already active, no second start supported" && exit 1
+    [ -f /var/run/sapconf/active ] && log "sapconf already active, no second start supported" && exit 0
     [ ! -d /var/run/sapconf ] && mkdir -p /var/run/sapconf
     touch /var/run/sapconf/active
 

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -210,10 +210,18 @@ set_scheduler() {
     # read block devices from /sys/block
     #for i in $(eval LANG=C ls -1 /sys/block 2>/dev/null); do
     for i in /sys/block/*; do
+        skip=false
         dev=${i##*/}
         # check block device type.
-	[ ! -f /sys/block/"$dev"/device/type ] && continue
-        [[ $(cat /sys/block/"$dev"/device/type) -ne 0 ]] && continue
+       if [ ! -f /sys/block/"$dev"/device/type ]; then
+            skip=true
+        elif [[ $(cat /sys/block/"$dev"/device/type) -ne 0 ]]; then
+            skip=true
+        fi
+        # virtio block devices do not have a 'type' file, need workaround
+        [[ "$dev" =~ vd* ]] && skip=false
+        $skip && continue
+
         # Only set scheduler for TYPE_DISK / 0x00
         # check, if IO_SCHEDULER includes a valid scheduler
         # use the first valid scheduler as new scheduler


### PR DESCRIPTION
change uuidd handling 
add workaround for virtio block devices in scheduler settings