### PR TITLE
simplifying scheduler handling during update

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -138,11 +138,11 @@ revert_preparation() {
 tune_uuidd_socket() {
     # paranoia: should not happen, because uuidd.socket should be enabled
     # by vendor preset and sapconf.service should start uuidd.socket.
-    if ! systemctl is-active uuidd.socket; then
+    if ! systemctl -q is-active uuidd.socket; then
         log "--- Going to start uuidd.socket"
         systemctl start uuidd.socket
     fi
-    if ! systemctl is-enabled uuidd.socket; then
+    if ! systemctl -q is-enabled uuidd.socket; then
         log "--- Going to enable uuidd.socket"
         systemctl enable uuidd.socket
     fi

--- a/lib/mv_tuned_conf.sh
+++ b/lib/mv_tuned_conf.sh
@@ -68,16 +68,6 @@ if [ -n "$CUSTOM_TCONF" ]; then
         TCVAL=$(grep "${pat}[[:blank:]]*=" $CUSTOM_TCONF | grep "^[^#]" | sed "s/ = /=/" | awk -F = '{print $2}')
         NLINE="$NNAME=$TCVAL"
         SCPAT=$(grep "$NNAME=" $SN | grep "^[^#]")
-        if [[ "$NNAME" == IO_SCHEDULER && -n "$SCPAT" ]]; then
-            if [ -n "$TCVAL" ]; then
-                if ! echo "$SCPAT" | sed 's/"//g' | awk -F = '{print $2}' | grep "$TCVAL" >/dev/null 2>&1; then
-                    echo "Add scheduler '$TCVAL' from '$CUSTOM_TCONF' to the list of schedulers in '$SN'"
-                    NLINE=${SCPAT//IO_SCHEDULER=\"/IO_SCHEDULER=\"$TCVAL }
-                else
-                    NLINE=$SCPAT
-                fi
-            fi
-        fi
         if [[ -n "$NLINE" && -n "$SCPAT" && "$NLINE" != "$SCPAT" ]]; then
             echo "Updating $SN line '$SCPAT' with line '$NLINE' from $CUSTOM_TCONF..."
             sed -i "s/$SCPAT/$NLINE/" $SN

--- a/lib/sapconf
+++ b/lib/sapconf
@@ -207,7 +207,7 @@ if [ -f /run/sapconf_during_pkg_inst ]; then
 fi
 
 log "--- /usr/sbin/sapconf called with '$1'"
-(systemctl -q is-enabled tuned || systemctl -q is-active tuned) && log "ATTENTION: tuned service is enabled/active, so we may encounter conflicting tuning values"
+(systemctl -q is-enabled tuned 2>/dev/null || systemctl -q is-active tuned) && log "ATTENTION: tuned service is enabled/active, so we may encounter conflicting tuning values"
 
 if [ "$1" != "status" ]; then
     # service should fail, if saptune.service is enabled or has exited / save


### PR DESCRIPTION
in case of an update and a customer specific tuned configuration exists in /etc/tuned/sap* the values for 'evelator' will be copied 1:1 from the tuned.conf file to the /etc/sysconfig/sapconf file