### PR TITLE
simplifying scheduler handling during update

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -125,7 +125,7 @@ if [ -f /run/sapconf_during_pkg_inst ]; then
 fi
 
 log "--- /usr/sbin/sapconf called with '$1'"
-(systemctl -q is-enabled tuned || systemctl -q is-active tuned) && log "ATTENTION: tuned service is enabled/active, so we may encounter conflicting tuning values"
+(systemctl -q is-enabled tuned 2>/dev/null || systemctl -q is-active tuned) && log "ATTENTION: tuned service is enabled/active, so we may encounter conflicting tuning values"
 
 if [ "$1" != "status" ]; then
     # service should fail, if saptune.service is enabled or has exited / save

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -214,12 +214,12 @@ revert_page_cache_limit() {
 tune_uuidd_socket() {
     # paranoia: should not happen, because uuidd.socket should be enabled
     # by vendor preset and sapconf.service should start uuidd.socket.
-    if ! systemctl is-active uuidd.socket; then
+    if ! systemctl -q is-active uuidd.socket; then
         log "--- Going to start uuidd.socket"
         systemctl enable uuidd.socket
         systemctl start uuidd.socket
     fi
-    if ! systemctl is-enabled uuidd.socket; then
+    if ! systemctl -q is-enabled uuidd.socket; then
         log "--- Going to enable uuidd.socket"
         systemctl enable uuidd.socket
     fi

--- a/lib/mv_tuned_conf.sh
+++ b/lib/mv_tuned_conf.sh
@@ -32,16 +32,6 @@ NNAME=IO_SCHEDULER
 TCVAL=$(grep "${pat}[[:blank:]]*=" "$CUSTOM_TCONF" | grep "^[^#]" | sed "s/ = /=/" | awk -F = '{print $2}')
 SCPAT=$(grep "$NNAME=" "$SN" | grep "^[^#]")
 NLINE="$NNAME=$TCVAL"
-if [ -n "$SCPAT" ]; then
-    if [ -n "$TCVAL" ]; then
-        if ! echo "$SCPAT" | sed 's/"//g' | awk -F = '{print $2}' | grep "$TCVAL" >/dev/null 2>&1; then
-            echo "Add scheduler '$TCVAL' from '$CUSTOM_TCONF' to the list of schedulers in '$SN'"
-            NLINE=${SCPAT//IO_SCHEDULER=\"/IO_SCHEDULER=\"$TCVAL }
-        else
-            NLINE=$SCPAT
-        fi
-    fi
-fi
 if [[ -n "$NLINE" && -n "$SCPAT" && "$NLINE" != "$SCPAT" ]]; then
     echo "Updating $SN line '$SCPAT' with line '$NLINE' from $CUSTOM_TCONF..."
     sed -i "s/$SCPAT/$NLINE/" "$SN"

--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -368,6 +368,7 @@ tune_ase() {
     save_value vm.nr_hugepages "$(sysctl -n vm.nr_hugepages)"
     chk_and_set_conf_val NUMBER_HUGEPAGES vm.nr_hugepages
 
+    cur_val=$(sed 's%.*\[\(.*\)\].*%\1%' /sys/kernel/mm/transparent_hugepage/enabled)
     THP=$(chk_conf_val THP "$cur_val")
     if [ "$cur_val" != "$THP" ]; then
         save_value thp "$cur_val"

--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -299,9 +299,9 @@ tune_ase() {
     for ulimit_type in soft hard; do
         sysconf_line="${ulimit_group} ${ulimit_type} memlock $MEMLOCK"
         limits_line=$(grep -E "^${ulimit_group}[[:space:]]+${ulimit_type}[[:space:]]+memlock+" /etc/security/limits.conf)
-        save_limit=0
+        save_limit=""
         if [ "$limits_line" ]; then
-            save_limit=$(${limits_line##*[[:space:]]})
+            save_limit=${limits_line##*[[:space:]]}
             sed -i "/$limits_line/d" /etc/security/limits.conf
         fi
         echo "$sysconf_line" >> /etc/security/limits.conf
@@ -445,7 +445,9 @@ revert_ase() {
         if [ "$limits_line" ]; then
             sed -i "/$limits_line/d" /etc/security/limits.conf
         fi
-        echo "$restore_line" >> /etc/security/limits.conf
+        if [ -n "$MEMLOCK" ]; then
+            echo "$restore_line" >> /etc/security/limits.conf
+        fi
     done
 
     # Restore THP

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -196,7 +196,7 @@ set_readahead() {
 	[ -f /sys/block/"$dev"/queue/read_ahead_kb ] && cur_val=$(get_sys_val /sys/block/"$dev"/queue/read_ahead_kb)
         if [ "$cur_val" != "$READAHEAD" ]; then
             [ -n "$cur_val" ] && save_value READ_AHEAD_"$dev" "$cur_val"
-            log "Change value of read_ahead_kb for block device '/sys/block/$dev' from '$cur_val' to '$READAHEAD'$READAHEAD'"
+            log "Change value of read_ahead_kb for block device '/sys/block/$dev' from '$cur_val' to '$READAHEAD'"
             echo "$READAHEAD" > /sys/block/"$dev"/queue/read_ahead_kb
         else
             log "Leaving read_ahead_kb for block device '/sys/block/$dev' unchanged at '$cur_val'"


### PR DESCRIPTION
in case of an update and a customer specific tuned configuration exists in /etc/tuned/sap* the values for 'elevator' will be copied 1:1 from the tuned.conf file to the /etc/sysconfig/sapconf file