### PR TITLE
Fix L3: sapconf v5 profile resides in a non temporary directory "/var…

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -55,7 +55,6 @@ start() {
       exit 0
     fi
     profile=${profile:-sapconf-netweaver}
-    echo "$profile" > /var/lib/sapconf/last_profile
     echo "$profile" > /run/sapconf_act_profile
 
     case  "$profile" in
@@ -167,6 +166,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-netweaver}
+    echo "$profile" > /var/lib/sapconf/last_profile
     echo "$profile" > /run/sapconf_act_profile
     tune_netweaver
   ;;
@@ -184,6 +184,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-hana}
+    echo "$profile" > /var/lib/sapconf/last_profile
     echo "$profile" > /run/sapconf_act_profile
     tune_hana
   ;;
@@ -201,6 +202,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-ase}
+    echo "$profile" > /var/lib/sapconf/last_profile
     echo "$profile" > /run/sapconf_act_profile
     tune_ase
   ;;
@@ -218,6 +220,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-bobj}
+    echo "$profile" > /var/lib/sapconf/last_profile
     echo "$profile" > /run/sapconf_act_profile
     tune_bobj
   ;;

--- a/bin/sapconf
+++ b/bin/sapconf
@@ -35,7 +35,7 @@ cd /usr/lib/sapconf || exit 1
 . common.sh
 . profiles.sh
 
-profile=$(cat /var/lib/sapconf/act_profile 2> /dev/null)
+profile=$(cat /run/sapconf_act_profile 2> /dev/null)
 
 start() {
     log "--- "
@@ -55,7 +55,8 @@ start() {
       exit 0
     fi
     profile=${profile:-sapconf-netweaver}
-    echo "$profile" > /var/lib/sapconf/act_profile
+    echo "$profile" > /var/lib/sapconf/last_profile
+    echo "$profile" > /run/sapconf_act_profile
 
     case  "$profile" in
     sapconf-netweaver)
@@ -92,8 +93,7 @@ stop() {
       log "no active sapconf tuning - profile=$profile -, so nothing to revert"
       exit 0
     else
-      echo "$profile" > /var/lib/sapconf/last_profile
-      > /var/lib/sapconf/act_profile
+      > /run/sapconf_act_profile
       case  "$profile" in
       sapconf-netweaver)
         log "--- Going to revert netweaver tuning techniques"
@@ -167,7 +167,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-netweaver}
-    echo "$profile" > /var/lib/sapconf/act_profile
+    echo "$profile" > /run/sapconf_act_profile
     tune_netweaver
   ;;
 
@@ -184,7 +184,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-hana}
-    echo "$profile" > /var/lib/sapconf/act_profile
+    echo "$profile" > /run/sapconf_act_profile
     tune_hana
   ;;
 
@@ -201,7 +201,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-ase}
-    echo "$profile" > /var/lib/sapconf/act_profile
+    echo "$profile" > /run/sapconf_act_profile
     tune_ase
   ;;
 
@@ -218,7 +218,7 @@ case "$1" in
       exit 1
     fi
     profile=${profile:-sapconf-bobj}
-    echo "$profile" > /var/lib/sapconf/act_profile
+    echo "$profile" > /run/sapconf_act_profile
     tune_bobj
   ;;
 

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -39,9 +39,9 @@ To activate a sapconf tuning profile, run as root:
 .PP
 /usr/sbin/sapconf <profile>
 .br
-valid values for <profile> are \fInetweaver\fP,\fIhana\fP, \fIb1\fP, \fIase\fP, \fIsybase\fP, \fIbobj\fP. The sapconf internal representation of these values will be stored in \fI/var/lib/sapconf/act_profile\fP.
+valid values for <profile> are \fInetweaver\fP,\fIhana\fP, \fIb1\fP, \fIase\fP, \fIsybase\fP, \fIbobj\fP. The sapconf internal representation of these values will be stored in \fI/run/sapconf_act_profile\fP.
 .PP
-For the sapconf internal representation (value stored in \fI/var/lib/sapconf/act_profile\fP or \fI/var/lib/sapconf/last_profile\fP) the following mapping will be used:
+For the sapconf internal representation (value stored in \fI/run/sapconf_act_profile\fP or \fI/var/lib/sapconf/last_profile\fP) the following mapping will be used:
 .br
 netweaver - sapconf-netweaver
 .br
@@ -73,7 +73,7 @@ If you see the error message:
 .br
 \fBnon-sapconf tuning profile configured. Skipping activation. See man sapconf for details.\fR
 
-please check the active sapconf tuning profile by '\fBcat /var/lib/sapconf/act_profile\fR' and change it to one of the pre\-defined profiles listed below by '\fB/usr/sbin/sapconf <profile>\fR'.
+please check the active sapconf tuning profile by '\fBcat /run/sapconf_act_profile\fR' and change it to one of the pre\-defined profiles listed below by '\fB/usr/sbin/sapconf <profile>\fR'.
 
 .SH PROFILES
 ATTENTION - Preview: starting with SLE15 we will no longer distinguish between different profiles.
@@ -185,7 +185,7 @@ Private copies of sapconf related former tuned profiles moved from /etc/tuned du
 contains the last used sapconf profile. The file will be written during stop of the sapconf service and the content will be used during start of the sapconf service.
 .RE
 .PP
-\fI/var/lib/sapconf/act_profile\fR
+\fI/run/sapconf_act_profile\fR
 .RS 4
 The file will be written during start of the sapconf service. It contains the current applied profile, if sapconf is active.
 .br

--- a/man/sapconf.8
+++ b/man/sapconf.8
@@ -37,7 +37,7 @@ If the start failed and you get the error message:
 .br
 \fBnon-sapconf tuning profile configured. Skipping activation. See man sapconf for details.\fR
 
-please check the active sapconf tuning profile by '\fBcat /var/lib/sapconf/act_profile\fR' and change it to one of the pre\-defined profiles listed below by '\fB/usr/sbin/sapconf <profile>\fR'.
+please check the active sapconf tuning profile by '\fBcat /run/sapconf_act_profile\fR' and change it to one of the pre\-defined profiles listed below by '\fB/usr/sbin/sapconf <profile>\fR'.
 
 .IP \[bu]
 reload - If a sapconf profile is active, stop and start the sapconf tuning.


### PR DESCRIPTION
…/lib/sapconf" ref:_00D1igLOd._5001iSsjJP:ref (bsc#1176565)

