### PR TITLE
changes for the next sapconf version 5.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/SUSE/sapconf.svg?branch=master)](https://travis-ci.org/SUSE/sapconf)
+[![shellcheck](https://github.com/SUSE/sapconf/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/SUSE/sapconf/actions/workflows/shellcheck.yml)
 
 # sapconf
 The utility adjusts operating system parameters, such as kernel tuning settings and resource limits, to allow running various SAP solutions at satisfactory performance.

--- a/bin/sapconf_check
+++ b/bin/sapconf_check
@@ -20,8 +20,8 @@
 # It will not dig deeper to check if the tuning itself is working.
 #
 # exit codes:       0   All checks ok. Sapconf has been set up correctly.
-#                   1   Some warnings occured. Sapconf should work, but better check manually.
-#                   2   Some errors occured. Sapconf will not work.
+#                   1   Some warnings occurred. Sapconf should work, but better check manually.
+#                   2   Some errors occurred. Sapconf will not work.
 #                   3   Wrong parameters given to the tool on commandline.
 #
 # Changelog:
@@ -407,11 +407,11 @@ function check_sapconf() {
                             print_ok "sapconf profile '${tool_profile['sapconf']#sapconf-}' is set"
                             ;; 
                         missing)
-                            print_fail "No sapconf profile is set!" "Please set a sapconf profile by running 'sapconf stop && sapconf <your choosen profile>'"
+                            print_fail "No sapconf profile is set!" "Please set a sapconf profile by running 'sapconf stop && sapconf <your chosen profile>'"
                             ((fails++))
                             ;;
                         *)
-                            print_fail "No sapconf profile: ${tool_profile['sapconf']}" "Please set a sapconf profile by running 'sapconf stop && sapconf <your choosen profile>'"
+                            print_fail "No sapconf profile: ${tool_profile['sapconf']}" "Please set a sapconf profile by running 'sapconf stop && sapconf <your chosen profile>'"
                             ((fails++))
                             ;;
                     esac

--- a/lib/adapt2newSNvalues.sh
+++ b/lib/adapt2newSNvalues.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# adapt new SAP Note value by changing /etc/sysconfig/sapconf entries
+
+# adapt2newSNvalues.sh is called by post script of sapconf package installation
+# to adapt new SAP Note values
+
+# SAP Note 1771258 - rev. 6 from 05.11.2021
+# change values from 65536 to 1048576
+# only change, if there are NO customer changes done
+change_nofile_limits() {
+OVAL="65536"
+NVAL="1048576"
+for ulimit_group in @sapsys @sdba @dba; do
+    for ulimit_type in soft hard; do
+        limits_line=$(grep -E "^LIMIT_[1-6]=.*${ulimit_group}[[:space:]]+${ulimit_type}[[:space:]]+nofile[[:space:]]+${OVAL}" "$SN")
+        if [ -n "$limits_line" ]; then
+            NLINE="${limits_line//$OVAL/$NVAL}"
+            if [[ -n "$NLINE" && "$NLINE" != "$limits_line" ]]; then
+                echo "Updating $SN with new SAP Note value '$NVAL' for existing entry '$limits_line'..."
+                sed -i "s/$limits_line/$NLINE/" "$SN"
+            fi
+        fi
+    done
+done
+}
+
+SN=/etc/sysconfig/sapconf
+change_nofile_limits

--- a/lib/mv_tuned_conf.sh
+++ b/lib/mv_tuned_conf.sh
@@ -11,7 +11,7 @@
 
 CUSTOM_TCONF=""
 SN=/etc/sysconfig/sapconf
-# check, if the tuned profile directories already availabe in the saved_config
+# check, if the tuned profile directories already available in the saved_config
 # area. If yes, may be backup/restore has added the already removed directories
 # again. So do not process the tuned profile values again to not harm the
 # current configuration in /etc/sysconfig/sapconf

--- a/lib/sccu.sh
+++ b/lib/sccu.sh
@@ -77,7 +77,7 @@ if ! $SCCU1; then
 #' $SN
 fi
 
-# additonal changed comments as requested in bsc#1096498
+# additional changed comments as requested in bsc#1096498
 if ! $SCCU1_15; then
     sed -i 's/, SAP Note 1557506$//' $SN
     sed -i 's/2205917/2684254/' $SN

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -311,12 +311,12 @@ set_force_latency() {
             save_value "${cpu}"_"${cstate}" "$old_state"
             # read /sys/devices/system/cpu/cpu*/cpuidle/state*/latency
             latency=$(cat "$cstate_path"/latency)
-            if [ "$latency" -ge "$FORCE_LATENCY" ]; then
+            if [ "$latency" -gt "$FORCE_LATENCY" ]; then
                 # set new latency states
                 log "Disable idle state for cpu '${cpu}' and state '${cstate}'"
                 echo 1 > "$cstate_path"/disable
             fi
-            if [[ $latency -lt $FORCE_LATENCY && $old_state -eq 1 ]]; then
+            if [[ $latency -le $FORCE_LATENCY && $old_state -eq 1 ]]; then
                 # reset previous set latency state
                 log "Enable idle state for cpu '${cpu}' and state '${cstate}'"
                 echo 0 > "$cstate_path"/disable

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -200,6 +200,55 @@ is_valid_scheduler() {
     return 1
 }
 
+# get the valid block devices for setting the scheduler
+get_valid_block_devices() {
+    # read block devices from /sys/block
+    candidates=()
+    excludedevs=()
+    for i in /sys/block/*; do
+        skip=false
+        dev=${i##*/}
+        if [ -f /sys/block/"$dev"/dm/uuid ]; then
+            if grep '^mpath-' /sys/block/"$dev"/dm/uuid >/dev/null 2>&1; then
+                candidates+=("$dev")
+                for s in /sys/block/"$dev"/slaves/*; do
+                    excludedevs+=("${s##*/}")
+                done
+            else
+                dm=$(sed 's/\(.*\)-.*/\1/' /sys/block/"$dev"/dm/uuid)
+                log "skipping device '$dev'($dm), not applicable"
+            fi
+        else
+            # check block device type.
+            if [ ! -f /sys/block/"$dev"/device/type ]; then
+                skip=true
+            elif [[ $(cat /sys/block/"$dev"/device/type) -ne 0 ]]; then
+                skip=true
+            fi
+            # virtio block devices (vd* and xvd*) and NVME devices do not have
+            # a 'type' file, need workaround
+            [[ "$dev" =~ ^x?vd* || "$dev" =~ ^nvme[0-9]+n[0-9]+$ ]] && skip=false
+            if $skip; then
+                log "skipping device '$dev', not applicable"
+                continue
+            fi
+            candidates+=("$dev")
+        fi
+    done
+    for bdev in "${candidates[@]}"; do
+        exclude=false
+        for edev in "${excludedevs[@]}"; do
+            if [ "$bdev" == "$edev" ]; then
+                log "skipping device '$bdev', not applicable for dm slaves"
+                exclude=true
+                break
+            fi
+        done
+        ! $exclude && disklist="$disklist $bdev"
+    done
+    echo "$disklist"
+}
+
 # set block device scheduler
 set_scheduler() {
     if [ -z "$IO_SCHEDULER" ]; then
@@ -207,22 +256,8 @@ set_scheduler() {
         log "Leaving block device scheduler settings unchanged"
         return 0
     fi
-    # read block devices from /sys/block
-    #for i in $(eval LANG=C ls -1 /sys/block 2>/dev/null); do
-    for i in /sys/block/*; do
-        skip=false
-        dev=${i##*/}
-        # check block device type.
-       if [ ! -f /sys/block/"$dev"/device/type ]; then
-            skip=true
-        elif [[ $(cat /sys/block/"$dev"/device/type) -ne 0 ]]; then
-            skip=true
-        fi
-        # virtio block devices do not have a 'type' file, need workaround
-        [[ "$dev" =~ vd* ]] && skip=false
-        $skip && continue
 
-        # Only set scheduler for TYPE_DISK / 0x00
+    for dev in $(get_valid_block_devices); do
         # check, if IO_SCHEDULER includes a valid scheduler
         # use the first valid scheduler as new scheduler
         if ! new_sched=$(is_valid_scheduler "$dev"); then

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -69,17 +69,17 @@ Linux kernel setting, set in the common part (tune_preparation) of the scripting
 SAP Note 941735, HANA Administration Guide
 .RE
 .PP
-\fBLIMIT_1="@sapsys soft nofile 65536"\fP
+\fBLIMIT_1="@sapsys soft nofile 1048576"\fP
 .br
-\fBLIMIT_2="@sapsys hard nofile 65536"\fP
+\fBLIMIT_2="@sapsys hard nofile 1048576"\fP
 .br
-\fBLIMIT_3="@sdba soft nofile 65536"\fP
+\fBLIMIT_3="@sdba soft nofile 1048576"\fP
 .br
-\fBLIMIT_4="@sdba hard nofile 65536"\fP
+\fBLIMIT_4="@sdba hard nofile 1048576"\fP
 .br
-\fBLIMIT_5="@dba soft nofile 65536"\fP
+\fBLIMIT_5="@dba soft nofile 1048576"\fP
 .br
-\fBLIMIT_6="@dba hard nofile 65536"\fP
+\fBLIMIT_6="@dba hard nofile 1048576"\fP
 .RS 4
 Maximum number of open files for SAP application groups sapsys, sdba, and dba.
 Consult with manual page limits.conf(5) for the correct syntax.
@@ -88,7 +88,7 @@ Limit settings in \fB/etc/security/limits.d/sapconf-nofile.conf\fP during the co
 .br
 This file will be removed during revert (change of tuning profile or stop of sapconf service.) and during the sapconf package removal.
 .br
-SAP Note 1771258
+SAP Note 1771258 (rev. 6 from 05.11.2021)
 .RE
 .RE
 .PP

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2017-2020 SUSE LLC
+.\" * Copyright (c) 2017-2022 SUSE LLC
 .\" * Authors: Angela Briel
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "March 2020" "sapconf configuration file"
+.TH sapconf 5 "January 2022" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -312,7 +312,17 @@ With the new introduced multi-queue scheduler for block layer devices the recomm
 
 So IO_SCHEDULER can now contain a list of possible schedulers, separated by blanks, which are checked from left to right. The first one which is available in /sys/block/<device>/queue/scheduler will be used as new scheduler setting for the respective block device.
 
-When set, all block devices on the system will be switched to one of the chosen schedulers.
+When set, all block devices on the system \fBvalid\fP for this sort of action will be switched to one of the chosen schedulers.
+
+The following rules apply for \fBvalid\fP devices:
+.RS 4
+.IP \[bu]
+all multipath devices (dm-*, if mpath-, but not LVM- or other dm-)
+.IP \[bu]
+all physical disks (indicated by device/type=0 or names like nvme*, vd*)
+.br
+\fBexcept\fP they are part of a device mapper construct (like mpath-).
+.RE
 .PP
 .RS 4
 Set in the common part (tune_preparation) of the scripting

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2015-2020 SUSE LLC
+.\" * Copyright (c) 2015-2022 SUSE LLC
 .\" * Authors: Howard Guo
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 7 "June 2020" "util-linux" "System Administration"
+.TH sapconf 7 "January 2022" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -26,7 +26,7 @@ sapconf is \fBno longer\fP working on top of the tuned daemon.
 .SH CONFIGURATION
 The main customization can be done in the central configuration file \fI/etc/sysconfig/sapconf\fP of sapconf.
 .br
-All parameters to be set by sapconf are descibed in detail within this file and will be read from this file.
+All parameters to be set by sapconf are described in detail within this file and will be read from this file.
 .br
 Bear in mind: Higher or lower system values set by the system, the SAP installer or by the administrator using sysctl command or sysctl configuration files will be overwritten by sapconf, if they are part of the sapconf sysconfig file.
 .br
@@ -131,7 +131,7 @@ The log file of sapconf will not be removed during package removal.
 .RS 4
 the central configuration file
 .br
-Here you can find all parameters, wich are affected by sapconf. The actual setting value, the source SAP Note, a short explanation and where this parameter is set.
+Here you can find all parameters, which are affected by sapconf. The actual setting value, the source SAP Note, a short explanation and where this parameter is set.
 .br
 If you change parameter values please don't forget to reload sapconf service to get the changes take effect.
 .PP

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -50,16 +50,16 @@ SHMMAX=18446744073709551615
 #
 # Maximum number of open files for SAP application groups sapsys, sdba, and dba.
 # Consult with manual page limits.conf(5) for the correct syntax.
-# Set to 65536
+# Set to 1048576 (as recommended by revision 6 of the SAP Note)
 #
-# SAP Note 1771258
+# SAP Note 1771258 (rev. 6 from 05.11.2021)
 #
-LIMIT_1="@sapsys soft nofile 65536"
-LIMIT_2="@sapsys hard nofile 65536"
-LIMIT_3="@sdba soft nofile 65536"
-LIMIT_4="@sdba hard nofile 65536"
-LIMIT_5="@dba soft nofile 65536"
-LIMIT_6="@dba hard nofile 65536"
+LIMIT_1="@sapsys soft nofile 1048576"
+LIMIT_2="@sapsys hard nofile 1048576"
+LIMIT_3="@sdba soft nofile 1048576"
+LIMIT_4="@sdba hard nofile 1048576"
+LIMIT_5="@dba soft nofile 1048576"
+LIMIT_6="@dba hard nofile 1048576"
 
 # vm.max_map_count
 # The value is the maximum number of memory map areas a process may have.


### PR DESCRIPTION
- change block device handling to handle multipath devices correctly.
  Only the DM multipath devices (mpath) will be used for the settings, but not its paths.
  (bsc#1188743)
- fixed wrong comparison used for setting force_latency
  (bsc#1185702)
- SAP Note 1771258 v6 updates nofile values to 1048576
  (bsc#1192841)
