### PR TITLE
fixes for new version 5.0.6 (sle12)

### DIFF
--- a/bin/sapconf
+++ b/bin/sapconf
@@ -117,14 +117,22 @@ stop() {
 }
 
 # main
+parent_command=$(tr -d '\0' </proc/$PPID/cmdline)
+log "--- /usr/sbin/sapconf called with '$1'"
+log "--- (from '$parent_command')"
+log "--- ('$(systemctl is-active sapconf.service)', '$(systemctl --no-legend list-jobs sapconf.service)')"
+
 if [ -f /run/sapconf_during_pkg_inst ]; then
     # workaround to prevent service reload during preun/postun from a previous
     # sapconf (with tuned support) package, which gets triggered during package
     # update of sapconf
-    exit 0
+    log "we are called during a package update (from '$parent_command')"
+    if chk_reload_lock; then
+        log "And 'IGNORE_RELOAD' is set in sapconf configuration file, so nothing to do"
+        exit 0
+    fi
 fi
 
-log "--- /usr/sbin/sapconf called with '$1'"
 (systemctl -q is-enabled tuned 2>/dev/null || systemctl -q is-active tuned) && log "ATTENTION: tuned service is enabled/active, so we may encounter conflicting tuning values"
 
 if [ "$1" != "status" ]; then
@@ -135,7 +143,6 @@ if [ "$1" != "status" ]; then
 fi
 
 case "$1" in
-  #start|restart|try-restart)
   start)
     # To remain compatible with the original implementation of sapconf,
     # if no sapconf related tuning is active, netwever tuning
@@ -145,7 +152,14 @@ case "$1" in
 
   reload|restart|try-restart)
     if [[ $profile == sapconf-* ]]; then
-      stop; profile=""; start
+      log "--- "
+      log "--- reloading sapconf ...."
+      if chk_reload_lock; then
+        log "'IGNORE_RELOAD' is set in sapconf configuration file, so no permission to $1"
+        exit 0
+      else
+        stop; profile=""; start
+      fi
     else
       log "no active sapconf tuning - profile=$profile -, so nothing to $1"
     fi

--- a/lib/sc_hooks.sh
+++ b/lib/sc_hooks.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# sc_hooks.sh is called by post script of sapconf package installation
+# to handle some special cases
+# e.g. handle special workaround for bsc#1209408
+
+if [ "$1" == "" ]; then
+    echo "ERROR: missing argument"
+    exit 1
+else
+    hook_opt="$1"
+fi  
+SN=/etc/sysconfig/sapconf
+
+add_ignore() {
+    sed -i 's/^IGNORE_RELOAD=.*/IGNORE_RELOAD=yes/' $SN
+}
+
+del_ignore() {
+    ignore="nothing"
+    entry=$(grep '^IGNORE_RELOAD="*yes"*' $SN)
+    no_entry=$(grep '^# bsc#1209408' $SN)
+    if [ -n "$entry" ] && [ -z "$no_entry" ]; then
+       ignore="add"
+       sed -i 's/^IGNORE_RELOAD=.*//' $SN
+    fi
+    echo $ignore
+}
+
+lc_add() {
+    sed -i 's%^# /etc/security/limits.conf%# /etc/security/limits.d/sapconf-nofile.conf%' "$SN"
+    sed -i 's/^# SAP Note 1771258$/# SAP Note 1771258 (rev. 6 from 05.11.2021)/' "$SN"
+    sed -i 's/^# Set to 65536/# Set to 1048576 (as recommended by revision 6 of the SAP Note)/' "$SN"
+}
+
+case "$hook_opt" in
+add)
+    add_ignore
+    lc_add
+    ;;
+del)
+    del_ignore
+    ;;
+nothing)
+    lc_add
+    ;;
+esac

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -579,3 +579,19 @@ chk_active_saptune() {
     fi
     return 0
 }
+
+# check IGNORE_RELOAD setting in the common configuration file sysconfig/sapconf
+chk_reload_lock() {
+    (if [ -r /etc/sysconfig/sapconf ]; then
+        source_sysconfig /etc/sysconfig/sapconf
+    else
+        log 'Failed to read /etc/sysconfig/sapconf'
+    fi
+    case "$IGNORE_RELOAD" in
+    yes|YES|true|0)
+        return 0 ;;
+    *)
+        return 1 ;;
+    esac)
+    return $?
+}

--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2017-2022 SUSE LLC
+.\" * Copyright (c) 2017-2023 SUSE LLC
 .\" * Authors: Angela Briel
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 5 "January 2022" "sapconf configuration file"
+.TH sapconf 5 "April 2023" "sapconf configuration file"
 .SH NAME
 sapconf \- central configuration file of sapconf
 
@@ -391,6 +391,14 @@ Set in the common part (tune_preparation) of the scripting
 .br
 SAP Note 1984787
 .RE
+.PP
+.TP 4
+.BI IGNORE_RELOAD="no"
+IGNORE_RELOAD does \fBnot\fR set a parameter to tune the system and has no related SAP Note.
+.br
+Instead IGNORE_RELOAD is used to control the '\fBsystemctl reload sapconf.service\fR' behavior. The default is '\fBno\fR', which means that the 'reload' is working as expected. Stopping and starting the tuning to apply changed parameter settings from the configuration \fI/etc/sysconfig/sapconf\fP.
+.br
+If set to '\fByes\fR' a '\fBsystemctl reload sapconf\fR' will do \fBnothing\fR.
 .PP
 .SH "FILES"
 .PP

--- a/man/sapconf.7
+++ b/man/sapconf.7
@@ -1,6 +1,6 @@
 .\"/* 
 .\" * All rights reserved
-.\" * Copyright (c) 2015-2022 SUSE LLC
+.\" * Copyright (c) 2015-2023 SUSE LLC
 .\" * Authors: Howard Guo
 .\" *
 .\" * This program is free software; you can redistribute it and/or
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH sapconf 7 "January 2022" "util-linux" "System Administration"
+.TH sapconf 7 "April 2023" "util-linux" "System Administration"
 .SH NAME
 sapconf \- Kernel and system configuration for SAP products
 
@@ -106,6 +106,24 @@ All settings are done according to SAP note number 900929, 941735, 1557506, 1771
 See the comments in the central sapconf configuration file \fI/etc/sysconfig/sapconf\fR or \fBsapconf(5)\fP for details.
 
 ATTENTION: Only chosen parts of the SAP Notes are implemented.
+
+.SH "PACKAGE INSTALLATION"
+If parameter values \fBchanged\fR in the central configuration file \fI/etc/sysconfig/sapconf\fP the package update of sapconf will detect and reload these changed values during the postrans section of the package update. This means for a short time the system is \fBNOT\fR fully tuned for SAP workloads.
+.br
+ATTENTION: To be on the safe side we recommend to run a sapconf package update with stopped SAP workloads, especially the HANA DB, to prevent crashes and data loss.
+
+To prevent sapconf from changing the systems tuning during a normal package update a parameter is available in the central configuration file \fI/etc/sysconfig/sapconf\fP.
+.TP 4
+.BI IGNORE_RELOAD="no"
+IGNORE_RELOAD is used to control the '\fBsystemctl reload sapconf.service\fR' behavior. The default is '\fBno\fR', which means that the 'reload' is working as expected. Stopping and starting the tuning to apply changed parameter settings from the configuration \fI/etc/sysconfig/sapconf\fP.
+.br
+If set to '\fByes\fR' a '\fBsystemctl reload sapconf\fR' will do \fBnothing\fR.
+
+During the package update this setting prevents the 'reload' of the sapconf related tuning parameter in the posttrans section of the update. Additional it influences the behavior of the restart running during the deinstallation section of the former package version.
+
+ATTENTION: If parameter settings in \fI/etc/sysconfig/sapconf\fP are changed during the package update, these settings are \fBnot\fR active after the package update. To activate please use '\fBsystemctl stop sapconf\fR' followed by '\fBsystemctl start sapconf\fR'.
+
+ATTENTION: If updateing from sapconf 4 to sapconf 5 the move from tuned to systemd is needed. In this case a stop of the tuning is needed during the pre install section and a start of the tuning in the postrans section of the package update is mandatory and will not be prevented by \fBIGNORE_RELOAD\fR.
 
 .SH "PACKAGE REQUIREMENTS"
 The following package requirements exist for the sapconf package:

--- a/sysconfig/sapconf
+++ b/sysconfig/sapconf
@@ -383,3 +383,10 @@ MIN_PERF_PCT=
 # SAP Note 1984787
 #
 IO_SCHEDULER="noop none"
+
+# IGNORE_RELOAD
+# bsc#1209408
+# IGNORE_RELOAD is used to control the 'systemctl reload sapconf.service'
+# behaviour.
+# Default is 'no'. If set to 'yes' a 'systemctl reload' will do nothing.
+IGNORE_RELOAD=no


### PR DESCRIPTION
add parameter IGNORE_RELOAD to /etc/sysconfig/sapconf to prevent sapconf from changing any system tunables during package update (bsc#1209408)

fix a race condition which leads to a missing start/restart of sapconf, which ends up with restored kernel parameters to defaults (bsc#1207899)