### PR TITLE
enhance description of THP section in man page sapconf(5)

### DIFF
--- a/man/sapconf.5
+++ b/man/sapconf.5
@@ -195,6 +195,8 @@ Set to 'never' to disable or to 'always' to enable or 'madvise'.
 .br
 \fBmadvise\fP will enter direct reclaim like 'always' but only for regions that
 are have used madvise(MADV_HUGEPAGE). This is the default behaviour.
+.br
+Due to the special manner of SAP HANA's memory management, it is recommended to configure THP to "madvise" starting with SLES 15 SP5 and higher.
 .PP
 .RS 4
 Set in \fB/sys/kernel/mm/transparent_hugepage/enabled\fP during the SAP tuning part of the scripting


### PR DESCRIPTION
man page sapconf(5) - add hint that the setting of 'madvise' for 'THP' is recommended starting with SLES 15 SP5 and higher (bsc#1232373)